### PR TITLE
feature/file-hosting-updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oxygen"
 uuid = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
 authors = ["Nathan Ortega <nate.ortega95@gmail.com>"]
-version = "1.1.6"
+version = "1.1.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -336,14 +336,14 @@ serve()
 
 ## Mounting Static Files
 
-You can mount static files using this handy macro which recursively searches a folder for files and mounts everything. All files are 
+You can mount static files using this handy function which recursively searches a folder for files and mounts everything. All files are 
 loaded into memory on startup.
 
 ```julia
 using Oxygen
 
 # mount all files inside the "content" folder under the "/static" path
-@staticfiles("content", "static")
+staticfiles("content", "static")
 
 # start the web server
 serve()
@@ -351,13 +351,13 @@ serve()
 
 ## Mounting Dynamic Files 
 
-Similar to @staticfiles, this macro mounts each path and re-reads the file for each request. This means that any changes to the files after the server has started will be displayed.
+Similar to staticfiles, this function mounts each path and re-reads the file for each request. This means that any changes to the files after the server has started will be displayed.
 
 ```julia
 using Oxygen
 
 # mount all files inside the "content" folder under the "/dynamic" path
-@dynamicfiles("content", "dynamic")
+dynamicfiles("content", "dynamic")
 
 # start the web server
 serve()
@@ -668,9 +668,9 @@ Used to register a function to a specific endpoint to handle that corresponding 
 Low-level macro that allows a route to be handle multiple request types
 
 
-#### @staticfiles
+#### staticfiles
 ```julia
-  @staticfiles(folder, mount)
+  staticfiles(folder, mount)
 ```
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |

--- a/demo/main.jl
+++ b/demo/main.jl
@@ -14,110 +14,113 @@ end
 # Add a supporting struct type definition to the Animal struct
 StructTypes.StructType(::Type{Animal}) = StructTypes.Struct()
 
-@get "/" function()
-    return "home"
-end
+# @get "/" function()
+#     return "home"
+# end
 
-@get "/killserver" function ()
-    terminate()
-end
+# @get "/killserver" function ()
+#     terminate()
+# end
 
-# add a default handler for unmatched requests
-@get "*" function () 
-    return "looks like you hit an endpoint that doesn't exist"
-end
+# # add a default handler for unmatched requests
+# @get "*" function () 
+#     return "looks like you hit an endpoint that doesn't exist"
+# end
 
-# You can also interpolate variables into the endpoint
-operations = Dict("add" => +, "multiply" => *)
-for (pathname, operator) in operations
-    @get "/$pathname/{a}/{b}" function (req, a::Float64, b::Float64)
-        return operator(a, b)
-    end
-end
+# # You can also interpolate variables into the endpoint
+# operations = Dict("add" => +, "multiply" => *)
+# for (pathname, operator) in operations
+#     @get "/$pathname/{a}/{b}" function (req, a::Float64, b::Float64)
+#         return operator(a, b)
+#     end
+# end
 
-# demonstate how to use path params (without type definitions)
-@get "/power/{a}/{b}" function (req::HTTP.Request, a::String, b::String)
-    return parse(Float64, a) ^ parse(Float64, b)
-end
+# # demonstate how to use path params (without type definitions)
+# @get "/power/{a}/{b}" function (req::HTTP.Request, a::String, b::String)
+#     return parse(Float64, a) ^ parse(Float64, b)
+# end
 
-# demonstrate how to use path params with type definitions
-@get "/divide/{a}/{b}" function (req::HTTP.Request, a::Float64, b::Float64)
-    return a / b
-end
+# # demonstrate how to use path params with type definitions
+# @get "/divide/{a}/{b}" function (req::HTTP.Request, a::Float64, b::Float64)
+#     return a / b
+# end
 
-# Return the body of the request as a string
-@post "/echo-text" function (req::HTTP.Request)
-    return text(req)
-end
+# # Return the body of the request as a string
+# @post "/echo-text" function (req::HTTP.Request)
+#     return text(req)
+# end
 
-# demonstrates how to serialize JSON into a julia struct 
-@post "/animal" function (req)
-    return json(req, Animal)
-end
+# # demonstrates how to serialize JSON into a julia struct 
+# @post "/animal" function (req)
+#     return json(req, Animal)
+# end
 
-# Return the body of the request as a JSON object
-@post "/echo-json" function (req::HTTP.Request)
-    return json(req)
-end
+# # Return the body of the request as a JSON object
+# @post "/echo-json" function (req::HTTP.Request)
+#     return json(req)
+# end
 
-# You can also return your own customized HTTP.Response object from an endpoint
-@get "/custom-response" function (req::HTTP.Request)
-    test_value = 77.8
-    return HTTP.Response(200, ["Content-Type" => "text/plain"], body = "$test_value")
-end
+# # You can also return your own customized HTTP.Response object from an endpoint
+# @get "/custom-response" function (req::HTTP.Request)
+#     test_value = 77.8
+#     return HTTP.Response(200, ["Content-Type" => "text/plain"], body = "$test_value")
+# end
 
-# Any object retuned from a function will automatically be converted into JSON (by default)
-@get "/json" function(req::HTTP.Request)
-    return Dict("message" => "hello world", "animal" => Animal(1, "cat", "whiskers"))
-end
+# # Any object retuned from a function will automatically be converted into JSON (by default)
+# @get "/json" function(req::HTTP.Request)
+#     return Dict("message" => "hello world", "animal" => Animal(1, "cat", "whiskers"))
+# end
 
-# show how to return a file from an endpoint
-@get "/files" function (req)
-    return file("main.jl")
-end
+# # show how to return a file from an endpoint
+# @get "/files" function (req)
+#     return file("main.jl")
+# end
 
-# show how to return a string that needs to be interpreted as html
-@get "/string-as-html" function (req)
-    message = "Hello World!"
-    return html("""
-        <!DOCTYPE html>
-            <html>
-            <body> 
-                <h1>$message</h1>
-            </body>
-        </html>
-    """)
-end
+# # show how to return a string that needs to be interpreted as html
+# @get "/string-as-html" function (req)
+#     message = "Hello World!"
+#     return html("""
+#         <!DOCTYPE html>
+#             <html>
+#             <body> 
+#                 <h1>$message</h1>
+#             </body>
+#         </html>
+#     """)
+# end
 
-@route ["GET", "POST"] "/demo" function(req)
-    return Animal(1, "cat", "whiskers")
-end
+# @route ["GET", "POST"] "/demo" function(req)
+#     return Animal(1, "cat", "whiskers")
+# end
 
 # recursively mount all files inside the demo folder ex.) demo/main.jl => /static/demo/main.jl 
-@staticfiles "content"
-@dynamicfiles "content" "dynamic"
+# staticfiles("content", "/")
+
+myvalue = "content"
+@staticfiles(myvalue)
 
 
 # CORS headers that show what kinds of complex requests are allowed to API
-headers = [
-    "Access-Control-Allow-Origin" => "*",
-    "Access-Control-Allow-Headers" => "*",
-    "Access-Control-Allow-Methods" => "GET, POST"
-]
+# headers = [
+#     "Access-Control-Allow-Origin" => "*",
+#     "Access-Control-Allow-Headers" => "*",
+#     "Access-Control-Allow-Methods" => "GET, POST"
+# ]
 
-function CorsHandler(handle)
-    return function(req::HTTP.Request)
-        # return headers on OPTIONS request
-        if HTTP.method(req) == "OPTIONS"
-            return HTTP.Response(200, headers)
-        else 
-            return handle(req)
-        end
-    end
-end
+# function CorsHandler(handle)
+#     return function(req::HTTP.Request)
+#         # return headers on OPTIONS request
+#         if HTTP.method(req) == "OPTIONS"
+#             return HTTP.Response(200, headers)
+#         else 
+#             return handle(req)
+#         end
+#     end
+# end
 
-# start the web server
-serve(middleware=[CorsHandler])
+# # start the web server
+# serve(middleware=[CorsHandler])
+serve()
 
 end
 

--- a/demo/main.jl
+++ b/demo/main.jl
@@ -14,109 +14,108 @@ end
 # Add a supporting struct type definition to the Animal struct
 StructTypes.StructType(::Type{Animal}) = StructTypes.Struct()
 
-# @get "/" function()
-#     return "home"
-# end
+@get "/" function()
+    return "home"
+end
 
-# @get "/killserver" function ()
-#     terminate()
-# end
+@get "/killserver" function ()
+    terminate()
+end
 
-# # add a default handler for unmatched requests
-# @get "*" function () 
-#     return "looks like you hit an endpoint that doesn't exist"
-# end
+# add a default handler for unmatched requests
+@get "*" function () 
+    return "looks like you hit an endpoint that doesn't exist"
+end
 
-# # You can also interpolate variables into the endpoint
-# operations = Dict("add" => +, "multiply" => *)
-# for (pathname, operator) in operations
-#     @get "/$pathname/{a}/{b}" function (req, a::Float64, b::Float64)
-#         return operator(a, b)
-#     end
-# end
+# You can also interpolate variables into the endpoint
+operations = Dict("add" => +, "multiply" => *)
+for (pathname, operator) in operations
+    @get "/$pathname/{a}/{b}" function (req, a::Float64, b::Float64)
+        return operator(a, b)
+    end
+end
 
-# # demonstate how to use path params (without type definitions)
-# @get "/power/{a}/{b}" function (req::HTTP.Request, a::String, b::String)
-#     return parse(Float64, a) ^ parse(Float64, b)
-# end
+# demonstate how to use path params (without type definitions)
+@get "/power/{a}/{b}" function (req::HTTP.Request, a::String, b::String)
+    return parse(Float64, a) ^ parse(Float64, b)
+end
 
-# # demonstrate how to use path params with type definitions
-# @get "/divide/{a}/{b}" function (req::HTTP.Request, a::Float64, b::Float64)
-#     return a / b
-# end
+# demonstrate how to use path params with type definitions
+@get "/divide/{a}/{b}" function (req::HTTP.Request, a::Float64, b::Float64)
+    return a / b
+end
 
-# # Return the body of the request as a string
-# @post "/echo-text" function (req::HTTP.Request)
-#     return text(req)
-# end
+# Return the body of the request as a string
+@post "/echo-text" function (req::HTTP.Request)
+    return text(req)
+end
 
-# # demonstrates how to serialize JSON into a julia struct 
-# @post "/animal" function (req)
-#     return json(req, Animal)
-# end
+# demonstrates how to serialize JSON into a julia struct 
+@post "/animal" function (req)
+    return json(req, Animal)
+end
 
-# # Return the body of the request as a JSON object
-# @post "/echo-json" function (req::HTTP.Request)
-#     return json(req)
-# end
+# Return the body of the request as a JSON object
+@post "/echo-json" function (req::HTTP.Request)
+    return json(req)
+end
 
-# # You can also return your own customized HTTP.Response object from an endpoint
-# @get "/custom-response" function (req::HTTP.Request)
-#     test_value = 77.8
-#     return HTTP.Response(200, ["Content-Type" => "text/plain"], body = "$test_value")
-# end
+# You can also return your own customized HTTP.Response object from an endpoint
+@get "/custom-response" function (req::HTTP.Request)
+    test_value = 77.8
+    return HTTP.Response(200, ["Content-Type" => "text/plain"], body = "$test_value")
+end
 
-# # Any object retuned from a function will automatically be converted into JSON (by default)
-# @get "/json" function(req::HTTP.Request)
-#     return Dict("message" => "hello world", "animal" => Animal(1, "cat", "whiskers"))
-# end
+# Any object retuned from a function will automatically be converted into JSON (by default)
+@get "/json" function(req::HTTP.Request)
+    return Dict("message" => "hello world", "animal" => Animal(1, "cat", "whiskers"))
+end
 
-# # show how to return a file from an endpoint
-# @get "/files" function (req)
-#     return file("main.jl")
-# end
+# show how to return a file from an endpoint
+@get "/files" function (req)
+    return file("main.jl")
+end
 
-# # show how to return a string that needs to be interpreted as html
-# @get "/string-as-html" function (req)
-#     message = "Hello World!"
-#     return html("""
-#         <!DOCTYPE html>
-#             <html>
-#             <body> 
-#                 <h1>$message</h1>
-#             </body>
-#         </html>
-#     """)
-# end
+# show how to return a string that needs to be interpreted as html
+@get "/string-as-html" function (req)
+    message = "Hello World!"
+    return html("""
+        <!DOCTYPE html>
+            <html>
+            <body> 
+                <h1>$message</h1>
+            </body>
+        </html>
+    """)
+end
 
-# @route ["GET", "POST"] "/demo" function(req)
-#     return Animal(1, "cat", "whiskers")
-# end
+@route ["GET", "POST"] "/demo" function(req)
+    return Animal(1, "cat", "whiskers")
+end
 
 # recursively mount all files inside the demo folder ex.) demo/main.jl => /static/demo/main.jl 
-# staticfiles("content", "/")
+staticfiles("content")
+dynamicfiles("content", "dynamic")
 
-myvalue = "content"
-@staticfiles(myvalue)
 
 
 # CORS headers that show what kinds of complex requests are allowed to API
-# headers = [
-#     "Access-Control-Allow-Origin" => "*",
-#     "Access-Control-Allow-Headers" => "*",
-#     "Access-Control-Allow-Methods" => "GET, POST"
-# ]
+headers = [
+    "Access-Control-Allow-Origin" => "*",
+    "Access-Control-Allow-Headers" => "*",
+    "Access-Control-Allow-Methods" => "GET, POST"
+]
 
-# function CorsHandler(handle)
-#     return function(req::HTTP.Request)
-#         # return headers on OPTIONS request
-#         if HTTP.method(req) == "OPTIONS"
-#             return HTTP.Response(200, headers)
-#         else 
-#             return handle(req)
-#         end
-#     end
-# end
+function CorsHandler(handle)
+    return function(req::HTTP.Request)
+        # return headers on OPTIONS request
+        if HTTP.method(req) == "OPTIONS"
+            return HTTP.Response(200, headers)
+        else 
+            return handle(req)
+        end
+    end
+end
 
 # # start the web server
 # serve(middleware=[CorsHandler])

--- a/demo/main.jl
+++ b/demo/main.jl
@@ -97,8 +97,6 @@ end
 staticfiles("content")
 dynamicfiles("content", "dynamic")
 
-
-
 # CORS headers that show what kinds of complex requests are allowed to API
 headers = [
     "Access-Control-Allow-Origin" => "*",
@@ -117,9 +115,8 @@ function CorsHandler(handle)
     end
 end
 
-# # start the web server
-# serve(middleware=[CorsHandler])
-serve()
+# start the web server
+serve(middleware=[CorsHandler])
 
 end
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,8 @@ serveparallel
 ```@docs
 @staticfiles
 @dynamicfiles
+staticfiles
+dynamicfiles
 file
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -336,14 +336,14 @@ serve()
 
 ## Mounting Static Files
 
-You can mount static files using this handy macro which recursively searches a folder for files and mounts everything. All files are 
+You can mount static files using this handy function which recursively searches a folder for files and mounts everything. All files are 
 loaded into memory on startup.
 
 ```julia
 using Oxygen
 
 # mount all files inside the "content" folder under the "/static" path
-@staticfiles("content", "static")
+staticfiles("content", "static")
 
 # start the web server
 serve()
@@ -351,13 +351,13 @@ serve()
 
 ## Mounting Dynamic Files 
 
-Similar to @staticfiles, this macro mounts each path and re-reads the file for each request. This means that any changes to the files after the server has started will be displayed.
+Similar to staticfiles, this function mounts each path and re-reads the file for each request. This means that any changes to the files after the server has started will be displayed.
 
 ```julia
 using Oxygen
 
 # mount all files inside the "content" folder under the "/dynamic" path
-@dynamicfiles("content", "dynamic")
+dynamicfiles("content", "dynamic")
 
 # start the web server
 serve()
@@ -668,9 +668,9 @@ Used to register a function to a specific endpoint to handle that corresponding 
 Low-level macro that allows a route to be handle multiple request types
 
 
-#### @staticfiles
+#### staticfiles
 ```julia
-  @staticfiles(folder, mount)
+  staticfiles(folder, mount)
 ```
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |

--- a/src/Oxygen.jl
+++ b/src/Oxygen.jl
@@ -7,7 +7,8 @@ include("util.jl" );        using .Util
 include("bodyparsers.jl");  using .BodyParsers
 include("core.jl");         using .Core
 
-export @get, @post, @put, @patch, @delete, @route, @staticfiles, @dynamicfiles, @cron,
+export @get, @post, @put, @patch, @delete, @route, @cron, 
+        @staticfiles, @dynamicfiles, staticfiles, dynamicfiles,
         serve, serveparallel, terminate, internalrequest, 
         redirect, queryparams, binary, text, json, html, file, 
         configdocs, mergeschema, setschema, getschema, router,

--- a/src/fileutil.jl
+++ b/src/fileutil.jl
@@ -5,7 +5,7 @@ using HTTP
 include("mimetypes.jl");    
 using .MimeTypes
 
-export file, mountedfolders, @mountfolder
+export file, mountedfolders, mountfolder
 
 """
     file(filepath::String)
@@ -33,17 +33,13 @@ function getfiles(folder::String)
 end
 
 """
-    @iteratefiles(folder::String, func::Function)
+    iteratefiles(func::Function, folder::String)
 
 Walk through all files in a directory and apply a function to each file
 """
-macro iteratefiles(folder::String, func)
-    local target_files::Array{String} = getfiles(folder)
-    quote
-        local action = $(esc(func))
-        for filepath in $target_files
-            action(filepath)
-        end
+function iteratefiles(func::Function, folder::String)
+    for filepath in getfiles(folder)
+        func(filepath)
     end
 end
 
@@ -59,53 +55,47 @@ end
 """
     mountfolder(folder::String, mountdir::String, addroute::Function)
 
-This macro is used to discover files & register them to the router while  
+This function is used to discover files & register them to the router while  
 leaving the `addroute` function to determine how to register the files
 """
-macro mountfolder(folder::String, mountdir::String, addroute)
-    quote 
-        local folder = $folder
-        local directory = $mountdir
-        local separator = Base.Filesystem.path_separator
+function mountfolder(folder::String, mountdir::String, addroute)
+    
+    separator = Base.Filesystem.path_separator
 
-        # track all registered paths 
-        local paths = Dict{String, Bool}()
+    # track all registered paths 
+    paths = Dict{String, Bool}()
 
-        @iteratefiles $folder function(filepath::String)
+    iteratefiles(folder) do filepath
 
-            # remove the first occurrence of the root folder from the filepath before "mounting"
-            local cleanedmountpath = replace(filepath, "$(folder)$(separator)" => "", count=1)
+        # remove the first occurrence of the root folder from the filepath before "mounting"
+        cleanedmountpath = replace(filepath, "$(folder)$(separator)" => "", count=1)
 
-            # generate the path to mount the file to
-            local mountpath = "/$directory/$cleanedmountpath"
+        # generate the path to mount the file to
+        mountpath = mountdir == "/" || isnothing(mountdir) || isempty(mountdir) || all(isspace, mountdir) ? "/$cleanedmountpath" : "/$mountdir/$cleanedmountpath"
 
-            # load file into memory on sever startup
-            local body = file(filepath)
+        # precalculate content type 
+        content_type = mimetype(filepath)
+        headers = ["Content-Type" => content_type]
 
-            # precalculate content type 
-            local content_type = mimetype(filepath) #HTTP.sniff(body)
-            local headers = ["Content-Type" => content_type]
+        paths[mountpath] = true 
+        # register the file route
+        addroute(mountpath, headers, filepath, paths)
 
-            paths[mountpath] = true 
-            # register the file route
-            addroute(mountpath, headers, filepath, paths)
+        # also register file to the root of each subpath if this file is an index.html
+        if endswith(mountpath, "/index.html")
 
-            # also register file to the root of each subpath if this file is an index.html
-            if endswith(mountpath, "/index.html")
+            # # add the route without the trailing "/" character
+            # bare_path = getbefore(mountpath, "/index.html")
+            # paths[bare_path] = true
+            # addroute(bare_path, headers, filepath, paths)
 
-                # # add the route without the trailing "/" character
-                # bare_path = getbefore(mountpath, "/index.html")
-                # paths[bare_path] = true 
-                # addroute(bare_path, headers, filepath, paths)
-
-                # add the route with the trailing "/" character
-                trimmedpath = getbefore(mountpath, "index.html")
-                paths[trimmedpath] = true 
-                addroute(trimmedpath, headers, filepath, paths)
-            
-            end
-
+            # add the route with the trailing "/" character
+            trimmedpath = getbefore(mountpath, "index.html")
+            paths[trimmedpath] = true
+            addroute(trimmedpath, headers, filepath, paths)
+        
         end
+
     end
     
 end


### PR DESCRIPTION
This pull request addresses this issue: #100 

- We deprecated the `@staticfiles` and `@dynamicfiles` macros and pointed them to use the new `staticfiles()` and `dynamicfiles()` functions. There was no real reason for these to be macros, they could've easily been regular functions from the beginning.
- These new filemounting functions can mount files at the root path "/"
- The old macros point to the new functions and these macros now support variables