### PR TITLE
allowing keyword arguments to pass to json3.read from oxygen.json

### DIFF
--- a/src/bodyparsers.jl
+++ b/src/bodyparsers.jl
@@ -48,7 +48,7 @@ function json(req::HTTP.Request, classtype)
 end
 
 """
-    json(request::HTTP.Request, classtype)
+    json(request::HTTP.Request; keyword_arguments...)
 
 Read the body of a HTTP.Request as JSON with additional arguments for the read/serializer.
 """

--- a/src/bodyparsers.jl
+++ b/src/bodyparsers.jl
@@ -27,25 +27,6 @@ function binary(req::HTTP.Request) :: Vector{UInt8}
     return eof(body) ? nothing : readavailable(body)
 end
 
-"""
-    json(request::HTTP.Request)
-
-Read the body of a HTTP.Request as JSON
-"""
-function json(req::HTTP.Request) :: JSON3.Object
-    body = IOBuffer(HTTP.payload(req))
-    return eof(body) ? nothing : JSON3.read(body)
-end
-
-"""
-    json(request::HTTP.Request, classtype)
-
-Read the body of a HTTP.Request as JSON and serialize it into a custom struct
-"""
-function json(req::HTTP.Request, classtype)
-    body = IOBuffer(HTTP.payload(req))
-    return eof(body) ? nothing : JSON3.read(body, classtype)    
-end
 
 """
     json(request::HTTP.Request; keyword_arguments...)
@@ -82,15 +63,6 @@ end
 
 
 """
-    json(response::HTTP.Response)
-
-Read the body of a HTTP.Response as JSON 
-"""
-function json(response::HTTP.Response) :: JSON3.Object
-    return JSON3.read(String(response.body))
-end
-
-"""
     json(response::HTTP.Response; keyword_arguments)
 
 Read the body of a HTTP.Response as JSON with additional keyword arguments
@@ -99,15 +71,6 @@ function json(response::HTTP.Response; kwargs...) :: JSON3.Object
     return JSON3.read(String(response.body); kwargs...)
 end
 
-
-"""
-    json(response::HTTP.Response, classtype)
-
-Read the body of a HTTP.Response as JSON and serialize it into a custom struct
-"""
-function json(response::HTTP.Response, classtype)
-    return JSON3.read(String(response.body), classtype)
-end
 
 """
     json(response::HTTP.Response, classtype; keyword_arguments)

--- a/src/bodyparsers.jl
+++ b/src/bodyparsers.jl
@@ -57,6 +57,16 @@ function json(req::HTTP.Request; kwargs...)
     return eof(body) ? nothing : JSON3.read(body; kwargs...)    
 end
 
+"""
+    json(request::HTTP.Request, classtype; keyword_arguments...)
+
+Read the body of a HTTP.Request as JSON with additional arguments for the read/serializer into a custom struct.
+"""
+function json(req::HTTP.Request, classtype; kwargs...)
+    body = IOBuffer(HTTP.payload(req))
+    return eof(body) ? nothing : JSON3.read(body, classtype; kwargs...)    
+end
+
 
 ### Helper functions used to parse the body of an HTTP.Response object
 
@@ -80,6 +90,15 @@ function json(response::HTTP.Response) :: JSON3.Object
     return JSON3.read(String(response.body))
 end
 
+"""
+    json(response::HTTP.Response; keyword_arguments)
+
+Read the body of a HTTP.Response as JSON with additional keyword arguments
+"""
+function json(response::HTTP.Response; kwargs...) :: JSON3.Object
+    return JSON3.read(String(response.body); kwargs...)
+end
+
 
 """
     json(response::HTTP.Response, classtype)
@@ -88,6 +107,15 @@ Read the body of a HTTP.Response as JSON and serialize it into a custom struct
 """
 function json(response::HTTP.Response, classtype)
     return JSON3.read(String(response.body), classtype)
+end
+
+"""
+    json(response::HTTP.Response, classtype; keyword_arguments)
+
+Read the body of a HTTP.Response as JSON with additional keyword arguments and serialize it into a custom struct
+"""
+function json(response::HTTP.Response, classtype; kwargs...)
+    return JSON3.read(String(response.body), classtype; kwargs...)
 end
 
 end

--- a/src/bodyparsers.jl
+++ b/src/bodyparsers.jl
@@ -37,7 +37,6 @@ function json(req::HTTP.Request) :: JSON3.Object
     return eof(body) ? nothing : JSON3.read(body)
 end
 
-
 """
     json(request::HTTP.Request, classtype)
 
@@ -46,6 +45,16 @@ Read the body of a HTTP.Request as JSON and serialize it into a custom struct
 function json(req::HTTP.Request, classtype)
     body = IOBuffer(HTTP.payload(req))
     return eof(body) ? nothing : JSON3.read(body, classtype)    
+end
+
+"""
+    json(request::HTTP.Request, classtype)
+
+Read the body of a HTTP.Request as JSON with additional arguments for the read/serializer.
+"""
+function json(req::HTTP.Request; kwargs...)
+    body = IOBuffer(HTTP.payload(req))
+    return eof(body) ? nothing : JSON3.read(body; kwargs...)    
 end
 
 

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -15,7 +15,7 @@ end
 # added supporting structype
 StructTypes.StructType(::Type{rank}) = StructTypes.Struct()
 
-@testset "json() struct keyword tests" begin 
+@testset "json() Request struct keyword tests" begin 
 
     req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")
     @test isnan(json(req, allow_inf = true)["message"][1])
@@ -30,7 +30,7 @@ StructTypes.StructType(::Type{rank}) = StructTypes.Struct()
 end
 
 
-@testset "json() stuct keyword with classtype" begin 
+@testset "json() Request stuct keyword with classtype" begin 
 
     req = HTTP.Request("GET","/", [],"""{"title": "viscount", "power": NaN}""")
     myjson = json(req, rank, allow_inf = true)
@@ -43,7 +43,7 @@ end
 end
 
 
-@testset "regular json() tests" begin 
+@testset "regular Request json() tests" begin 
 
     req = HTTP.Request("GET", "/json", [], "{\"message\":[null,1.0]}")
     @test isnothing(json(req)["message"][1])
@@ -62,7 +62,7 @@ end
 end
 
 
-@testset "json() with classtype" begin 
+@testset "json() Request with classtype" begin 
 
     req = HTTP.Request("GET","/", [],"""{"title": "viscount", "power": NaN}""")
     myjson = json(req, rank)
@@ -82,5 +82,87 @@ end
     @test myjson.power == 9000.1
 
 end
+
+
+@testset "json() Response" begin 
+
+    res = HTTP.Response("""{"title": "viscount", "power": 9000.1}""")
+    myjson = json(res)
+    @test myjson["power"] == 9000.1
+
+    res = HTTP.Response("""{"title": "viscount", "power": 9000.1}""")
+    myjson = json(res, rank)
+    @test myjson.power == 9000.1
+
+end
+
+@testset "json() Response struct keyword tests" begin 
+
+    req = HTTP.Response("{\"message\":[NaN,1.0]}")
+    @test isnan(json(req, allow_inf = true)["message"][1])
+    @test !isnan(json(req, allow_inf = true)["message"][2])
+
+    req = HTTP.Response("{\"message\":[Inf,1.0]}")
+    @test isinf(json(req, allow_inf = true)["message"][1])
+
+    req = HTTP.Response("{\"message\":[null,1.0]}")
+    @test isnothing(json(req, allow_inf = false)["message"][1])
+
+end
+
+
+@testset "json() Response stuct keyword with classtype" begin 
+
+    req = HTTP.Response("""{"title": "viscount", "power": NaN}""")
+    myjson = json(req, rank, allow_inf = true)
+    @test isnan(myjson.power)
+
+    req = HTTP.Response("""{"title": "viscount", "power": 9000.1}""")
+    myjson = json(req, rank, allow_inf = false)
+    @test myjson.power == 9000.1
+
+end
+
+
+@testset "regular json() Response tests" begin 
+
+    req = HTTP.Response("{\"message\":[null,1.0]}")
+    @test isnothing(json(req)["message"][1])
+    @test json(req)["message"][2] == 1
+
+    req = HTTP.Response("""{"message":["hello",1.0]}""")
+    @test json(req)["message"][1] == "hello"
+    @test json(req)["message"][2] == 1
+
+    req = HTTP.Response("{\"message\":[3.4,4.0]}")
+    @test json(req)["message"][1] == 3.4
+    @test json(req)["message"][2] == 4
+
+    req = HTTP.Response("{\"message\":[null,1.0]}")
+    @test isnothing(json(req)["message"][1])
+end
+
+
+@testset "json() Response with classtype" begin 
+
+    req = HTTP.Response("""{"title": "viscount", "power": NaN}""")
+    myjson = json(req, rank)
+    @test isnan(myjson.power)
+
+    req = HTTP.Response("""{"title": "viscount", "power": 9000.1}""")
+    myjson = json(req, rank)
+    @test myjson.power == 9000.1
+
+    # test invalid json
+    req = HTTP.Response("""{}""")
+    @test_throws MethodError json(req, rank) 
+
+    # test extra key
+    req = HTTP.Response("""{"title": "viscount", "power": 9000.1, "extra": "hi"}""")
+    myjson = json(req, rank)
+    @test myjson.power == 9000.1
+
+end
+
 
 end

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -1,0 +1,23 @@
+
+module BodyParserTests 
+using Test
+using HTTP
+
+include("../src/Oxygen.jl")
+using .Oxygen
+
+@testset "json() struct keyword tests" begin 
+
+    req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")
+    @test isnan(json(req, allow_inf = true)["message"][1])
+    @test !isnan(json(req, allow_inf = true)["message"][2])
+
+    req = HTTP.Request("GET", "/json", [], "{\"message\":[Inf,1.0]}")
+    @test isinf(json(req, allow_inf = true)["message"][1])
+
+    req = HTTP.Request("GET", "/json", [], "{\"message\":[null,1.0]}")
+    @test isnothing(json(req, allow_inf = false)["message"][1])
+
+end
+
+end

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -15,6 +15,9 @@ end
 # added supporting structype
 StructTypes.StructType(::Type{rank}) = StructTypes.Struct()
 
+req = HTTP.Request("GET", "/json", [], """{"message":["hello",1.0]}""")
+json(req)
+
 @testset "json() Request struct keyword tests" begin 
 
     req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -6,6 +6,11 @@ using HTTP
 include("../src/Oxygen.jl")
 using .Oxygen
 
+struct rank
+    title  :: String 
+    power   :: Float64
+end
+
 @testset "json() struct keyword tests" begin 
 
     req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")
@@ -17,6 +22,14 @@ using .Oxygen
 
     req = HTTP.Request("GET", "/json", [], "{\"message\":[null,1.0]}")
     @test isnothing(json(req, allow_inf = false)["message"][1])
+
+    req = HTTP.Request("GET","/", [],"""{"title": "viscount", "power": NaN}""")
+    myjson = json(req, rank, allow_inf = true)
+    @test isnan(myjson.power)
+
+    req = HTTP.Request("GET","/", [],"""{"title": "viscount", "power": 9000.1}""")
+    myjson = json(req, rank, allow_inf = false)
+    @test myjson.power == 9000.1
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -435,6 +435,18 @@ r = internalrequest(HTTP.Request("GET", """/struct/{"aged": 20}"""))
 r = internalrequest(HTTP.Request("GET", """/struct/{"aged": 20}"""))
 @test r.status == 500
 
+#struct request tests
+
+req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")
+@test isnan(json(req, allow_inf = true)["message"][1])
+@test !isnan(json(req, allow_inf = true)["message"][2])
+
+req = HTTP.Request("GET", "/json", [], "{\"message\":[Inf,1.0]}")
+@test isinf(json(req, allow_inf = true)["message"][1])
+
+req = HTTP.Request("GET", "/json", [], "{\"message\":[null,1.0]}")
+@test isnothing(json(req, allow_inf = false)["message"][1])
+
 # float 
 r = internalrequest(HTTP.Request("GET", "/float/3.5"))
 @test r.status == 200

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using StructTypes
 using Sockets
 using Dates 
 
+include("bodyparsertests.jl")
 include("crontests.jl")
 
 include("../src/Oxygen.jl")
@@ -434,18 +435,6 @@ r = internalrequest(HTTP.Request("GET", """/struct/{"aged": 20}"""))
 
 r = internalrequest(HTTP.Request("GET", """/struct/{"aged": 20}"""))
 @test r.status == 500
-
-#struct request tests
-
-req = HTTP.Request("GET", "/json", [], "{\"message\":[NaN,1.0]}")
-@test isnan(json(req, allow_inf = true)["message"][1])
-@test !isnan(json(req, allow_inf = true)["message"][2])
-
-req = HTTP.Request("GET", "/json", [], "{\"message\":[Inf,1.0]}")
-@test isinf(json(req, allow_inf = true)["message"][1])
-
-req = HTTP.Request("GET", "/json", [], "{\"message\":[null,1.0]}")
-@test isnothing(json(req, allow_inf = false)["message"][1])
 
 # float 
 r = internalrequest(HTTP.Request("GET", "/float/3.5"))


### PR DESCRIPTION
In order to parse json files which included inf and nan's it is required to pass along the keyword arguments.
oxygen.json is not able to do this yet, therefore adding this functionality.

I am leaving open the combination of custom struct + passing keyword arguments of the form json(request, classtype; keywordargs), this can be added later if required.