### PR TITLE
Allow custom stream handlers to be pass to serve/serveparallel

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -125,7 +125,7 @@ function stream_handler(middleware::Function)
 end 
 
 """
-    serve(; middleware::Vector=[], host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, kwargs...)
+    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, kwargs...)
 
 Start the webserver with your own custom request handler
 """
@@ -140,7 +140,7 @@ function serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1"
 end
 
 """
-    serveparallel(; middleware::Vector=[], host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, kwargs...)
+    serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, kwargs...)
 
 Starts the webserver in streaming mode with your own custom request handler and spawns n - 1 worker 
 threads to process individual requests. A Channel is used to schedule individual requests in FIFO order. 

--- a/src/core.jl
+++ b/src/core.jl
@@ -129,12 +129,12 @@ end
 
 Start the webserver with your own custom request handler
 """
-function serve(; middleware::Vector=[], host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, kwargs...)
+function serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, kwargs...)
     # compose our middleware ahead of time (so it only has to be built up once)
     configured_middelware = setupmiddleware(middleware=middleware, serialize=serialize, catch_errors=catch_errors)
 
     startserver(host, port, kwargs, async, (kwargs) ->  
-        HTTP.serve!(stream_handler(configured_middelware), host, port; kwargs...)
+        HTTP.serve!(handler(configured_middelware), host, port; kwargs...)
     )
     server[] # this value is returned if startserver() is ran in async mode
 end
@@ -146,12 +146,12 @@ Starts the webserver in streaming mode with your own custom request handler and 
 threads to process individual requests. A Channel is used to schedule individual requests in FIFO order. 
 Requests in the channel are then removed & handled by each the worker threads asynchronously. 
 """
-function serveparallel(; middleware::Vector=[], host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, kwargs...)
+function serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, kwargs...)
     # compose our middleware ahead of time (so it only has to be built up once)
     configured_middelware = setupmiddleware(middleware=middleware, serialize=serialize, catch_errors=catch_errors)
 
     startserver(host, port, kwargs, async, (kwargs) -> 
-        StreamUtil.start(stream_handler(configured_middelware); host=host, port=port, queuesize=queuesize, kwargs...)
+        StreamUtil.start(handler(configured_middelware); host=host, port=port, queuesize=queuesize, kwargs...)
     )
     server[] # this value is returned if startserver() is ran in async mode
 end


### PR DESCRIPTION
This PR allows a custom stream handler to be passed. This can be used to hook into things not currently exposed by `serve`/`serveparallel`.

I am using this patch together with the below code to mix websockets and Oxygen routes.

```
function handle_ws(ws)
    for msg in ws
        @info "Received message: $msg"
        send(ws, msg)
    end
end

function ws_handler(middleware::Function)
    inner = stream_handler(middleware)
    (stream::HTTP.Stream) -> begin
        path = HTTP.URI(stream.message.target).path
        if (
            HTTP.WebSockets.is_upgrade(stream.message) &&
            path == "/ws" &&
            stream.message.method == "GET"
        )
            HTTP.WebSockets.upgrade(handle_ws, stream)
        else
            inner(stream)
        end
    end
end
```

An alternative for this use case would be to add `@ws` routes, but this would probably mean writing routing logic beyond the current thin-wrapper of HTTP.jl router.

Another possible direction would be to add stream middleware, but I'm not entirely sure how generally useful this is. Possibly getting the IP address from the stream and putting it on the request object is so existing code that is also a sort of "stream middleware". Not sure about this either though.

Since I'm a bit negative/unsure of the alternatives, I'm therefore submitting this PR as a minimal change to allow for users to implement websockets --- or anything else that needs access to the raw connection --- themselves.

What do you think? Is this okay, or are you more keen on one of the alternatives?