### PR TITLE
feature/custom-headers-for-mounted-files

### DIFF
--- a/demo/dynamicheadersdemo.jl
+++ b/demo/dynamicheadersdemo.jl
@@ -1,0 +1,20 @@
+module DynamicHeadersDemo
+
+include("../src/Oxygen.jl")
+using .Oxygen
+using HTTP
+
+get("/") do req::HTTP.Request
+    return "hello world!"
+end
+
+# This function allows us to customize the headers on our static & dynamic resources
+function customize_headers(route::String, content_type::String, headers::Vector)
+    return [headers; "My-Header" => "hello world!"]
+end
+
+staticfiles("content", set_headers=customize_headers)
+
+serve()
+
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -578,28 +578,28 @@ end
 
 
 """
-    @staticfiles(folder::String, mountdir::String)
+    @staticfiles(folder::String, mountdir::String, set_headers::Union{Function,Nothing}=nothing)
 
 Mount all files inside the /static folder (or user defined mount point)
 """
-macro staticfiles(folder, mountdir="static")
+macro staticfiles(folder, mountdir="static", set_headers=nothing)
     printstyled("@staticfiles macro is deprecated, please use the staticfiles() function instead\n", color = :red, bold = true) 
     quote
-        staticfiles($(esc(folder)), $(esc(mountdir))) 
+        staticfiles($(esc(folder)), $(esc(mountdir)), set_headers=$(esc(set_headers))) 
     end
 end
 
 
 """
-    @dynamicfiles(folder::String, mountdir::String)
+    @dynamicfiles(folder::String, mountdir::String, set_headers::Union{Function,Nothing}=nothing)
 
 Mount all files inside the /static folder (or user defined mount point), 
 but files are re-read on each request
 """
-macro dynamicfiles(folder, mountdir="static")
+macro dynamicfiles(folder, mountdir="static", set_headers=nothing)
     printstyled("@dynamicfiles macro is deprecated, please use the dynamicfiles() function instead\n", color = :red, bold = true) 
     quote
-        dynamicfiles($(esc(folder)), $(esc(mountdir))) 
+        dynamicfiles($(esc(folder)), $(esc(mountdir)), set_headers=$(esc(set_headers))) 
     end      
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -605,14 +605,17 @@ end
 
 
 """
-    staticfiles(folder::String, mountdir::String)
+    staticfiles(folder::String, mountdir::String; set_headers::Union{Function,Nothing}=nothing)
 
-Mount all files inside the /static folder (or user defined mount point)
+Mount all files inside the /static folder (or user defined mount point). 
+The `set_headers` callback is passed the route, mime type, and the current headers for the given 
+resource and should return a finalized vector of pairs to use as the headers in the outgoing Request
 """
-function staticfiles(folder::String, mountdir::String="static")
+function staticfiles(folder::String, mountdir::String="static"; set_headers::Union{Function,Nothing}=nothing)
     registermountedfolder(mountdir)
-    function addroute(currentroute, headers, filepath, registeredpaths; code=200)
+    function addroute(currentroute, content_type, derived_headers, filepath, registeredpaths; code=200)
         body = file(filepath)
+        headers = !isnothing(set_headers) ? set_headers(currentroute, content_type, derived_headers) : derived_headers
         @get "$currentroute" function(req)
             # return 404 for paths that don't match our files
             validpath::Bool = get(registeredpaths, req.target, false)
@@ -624,14 +627,18 @@ end
 
 
 """
-    dynamicfiles(folder::String, mountdir::String)
+    dynamicfiles(folder::String, mountdir::String; set_headers::Union{Function,Nothing}=nothing)
 
 Mount all files inside the /static folder (or user defined mount point), 
-but files are re-read on each request
+but files are re-read on each request.
+The `set_headers` callback is passed the route, mime type, and the current headers for the given 
+resource and should return a finalized vector of pairs to use as the headers in the outgoing Request.
 """
-function dynamicfiles(folder::String, mountdir::String="static")
+function dynamicfiles(folder::String, mountdir::String="static"; set_headers::Union{Function,Nothing}=nothing)
     registermountedfolder(mountdir)
-    function addroute(currentroute, headers, filepath, registeredpaths; code = 200)
+    function addroute(currentroute, content_type, derived_headers, filepath, registeredpaths; code = 200)
+        # We can precompute the headers ahead of time because while the file can change - the name and exstension shouldn't
+        headers = !isnothing(set_headers) ? set_headers(currentroute, content_type, derived_headers) : derived_headers
         @get "$currentroute" function(req)   
             # return 404 for paths that don't match our files
             validpath::Bool = get(registeredpaths, req.target, false)

--- a/src/fileutil.jl
+++ b/src/fileutil.jl
@@ -80,7 +80,7 @@ function mountfolder(folder::String, mountdir::String, addroute)
 
         paths[mountpath] = true 
         # register the file route
-        addroute(mountpath, headers, filepath, paths)
+        addroute(mountpath, content_type, headers, filepath, paths)
 
         # also register file to the root of each subpath if this file is an index.html
         if endswith(mountpath, "/index.html")
@@ -93,7 +93,7 @@ function mountfolder(folder::String, mountdir::String, addroute)
             # add the route with the trailing "/" character
             trimmedpath = getbefore(mountpath, "index.html")
             paths[trimmedpath] = true
-            addroute(trimmedpath, headers, filepath, paths)
+            addroute(trimmedpath, content_type, headers, filepath, paths)
         
         end
 


### PR DESCRIPTION
Related Issue: #111 
- both `staticfiles` & `dynamicfiles` now have a `set_headers` keyword arg that takes a function that can be used to customize the headers for all mounted files.

Here's an example of it in use:
```julia
using Oxygen
using HTTP

get("/") do req::HTTP.Request
    return "hello world!"
end

# This function allows us to customize the headers on our static & dynamic resources
function customize_headers(route::String, content_type::String, headers::Vector)
    return [headers; "My-Header" => "hello world!"]
end

staticfiles("content", set_headers=customize_headers)

serve()
```