### PR TITLE
bugfix/duplicate-headers-from-renderers

### DIFF
--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -444,7 +444,7 @@ end
 function redochtml() :: HTTP.Response
     redocjs = readstaticfile("$REDOC_VERSION/redoc.standalone.js")
 
-    body = """
+    html("""
     <!DOCTYPE html>
     <html lang="en">
     
@@ -462,9 +462,7 @@ function redochtml() :: HTTP.Response
         </body>
     
     </html>
-    """
-    headers = ["Content-Type" => "text/html; charset=utf-8", "Content-Length" => string(sizeof(body))]
-    return HTTP.Response(200, headers; body=body)
+    """)
 end
 
 """
@@ -476,7 +474,7 @@ function swaggerhtml() :: HTTP.Response
     swaggerjs = readstaticfile("$SWAGGER_VERSION/swagger-ui-bundle.js")
     swaggerstyles = readstaticfile("$SWAGGER_VERSION/swagger-ui.css")
 
-    body = """
+    html("""
         <!DOCTYPE html>
         <html lang="en">
         
@@ -502,9 +500,7 @@ function swaggerhtml() :: HTTP.Response
         </body>
         
         </html>
-    """
-    headers = ["Content-Type" => "text/html; charset=utf-8", "Content-Length" => string(sizeof(body))]
-    return HTTP.Response(200, headers; body=body)
+    """)
 end
 
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -133,7 +133,7 @@ function stream_handler(middleware::Function)
 end 
 
 """
-    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, metrics=true, kwargs...)
+    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, kwargs...)
 
 Start the webserver with your own custom request handler
 """
@@ -164,7 +164,7 @@ function serve(;
 end
 
 """
-    serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, metrics=true, kwargs...)
+    serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, kwargs...)
 
 Starts the webserver in streaming mode with your own custom request handler and spawns n - 1 worker 
 threads to process individual requests. A Channel is used to schedule individual requests in FIFO order. 

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -114,7 +114,7 @@ function handlerequest(getresponse::Function, catch_errors::Bool)
             return getresponse()       
         catch error
             @error "ERROR: " exception=(error, catch_backtrace())
-            return HTTP.Response(500, "The Server encountered a problem")
+            return json(("message" => "The Server encountered a problem"), status = 500)    
         end  
     end
 end

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -147,11 +147,6 @@ function set_content_size!(body::Union{Base.CodeUnits{UInt8, String}, Vector{UIn
     end
 end
 
-function format_response!(req::HTTP.Request, render::Renderer)
-    # Return Renderer's directly because they already content-length & content-type headers
-    req.response = render.response
-end
-
 function format_response!(req::HTTP.Request, resp::HTTP.Response)
     # Return Response's as is without any modifications
     req.response = resp

--- a/src/utilities/render.jl
+++ b/src/utilities/render.jl
@@ -3,110 +3,106 @@ using HTTP
 using JSON3
 using MIMEs
 
-export Renderer, html, text, json, xml, js, css, binary, file
-
-struct Renderer 
-    response::HTTP.Response
-end
+export html, text, json, xml, js, css, binary, file
 
 """
-    html(content::String; status::Int, headers::Pair)
+    html(content::String; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as HTML
 """
-function html(content::String; status = 200, headers = []) :: Renderer
+function html(content::String; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "text/html; charset=utf-8",
         "Content-Length" => string(sizeof(content))
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 """
-    text(content::String; status::Int, headers::Pair)
+    text(content::String; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as plain text
 """
-function text(content::String; status = 200, headers = []) :: Renderer
+function text(content::String; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "text/plain; charset=utf-8",
         "Content-Length" => string(sizeof(content))
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 """
-    json(content::Any; status::Int, headers::Pair)
+    json(content::Any; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as JSON
 """
-function json(content::Any; status = 200, headers = []) :: Renderer
+function json(content::Any; status = 200, headers = []) :: HTTP.Response
     body = JSON3.write(content)
     push!(headers, 
         "Content-Type" => "application/json; charset=utf-8",
         "Content-Length" => string(sizeof(body))
     )
-    return HTTP.Response(status, headers, body = body) |> Renderer
+    return HTTP.Response(status, headers, body = body)
 end
 
 """
-    xml(content::String; status::Int, headers::Pair)
+    xml(content::String; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as XML
 """
-function xml(content::String; status = 200, headers = []) :: Renderer
+function xml(content::String; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "application/xml; charset=utf-8",
         "Content-Length" => string(sizeof(content))
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 """
-    js(content::String; status::Int, headers::Pair)
+    js(content::String; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as JavaScript
 """
-function js(content::String; status = 200, headers = []) :: Renderer
+function js(content::String; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "application/javascript; charset=utf-8",
         "Content-Length" => string(sizeof(content))
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 
 """
-    css(content::String; status::Int, headers::Pair)
+    css(content::String; status::Int, headers::Vector{Pair})
 
 A convenience function to return a String that should be interpreted as CSS
 """
-function css(content::String; status = 200, headers = []) :: Renderer
+function css(content::String; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "text/css; charset=utf-8",
         "Content-Length" => string(sizeof(content)), 
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 """
-    binary(content::Vector{UInt8}; status::Int, headers::Pair)
+    binary(content::Vector{UInt8}; status::Int, headers::Vector{Pair})
 
 A convenience function to return a Vector of UInt8 that should be interpreted as binary data
 """
-function binary(content::Vector{UInt8}; status = 200, headers = []) :: Renderer
+function binary(content::Vector{UInt8}; status = 200, headers = []) :: HTTP.Response
     push!(headers, 
         "Content-Type" => "application/octet-stream",
         "Content-Length" => string(sizeof(content))
     )
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end
 
 
 """
-    file(filepath::String; loadfile=nothing, status = 200, headers = []) :: Renderer
+    file(filepath::String; loadfile=nothing, status = 200, headers = []) :: HTTP.Response
 
-Reads a file and returns a Renderer object. The file is read as binary. If the file does not exist, 
+Reads a file and returns a HTTP.Response. The file is read as binary. If the file does not exist, 
 an ArgumentError is thrown. The MIME type and the size of the file are added to the headers.
 
 # Arguments
@@ -116,13 +112,13 @@ an ArgumentError is thrown. The MIME type and the size of the file are added to 
 - `headers`: Any additional headers to be included in the response. Defaults to an empty array.
 
 # Returns
-- A Renderer object containing the HTTP response.
+- A HTTP response.
 """
-function file(filepath::String; loadfile = nothing, status = 200, headers = []) :: Renderer
+function file(filepath::String; loadfile = nothing, status = 200, headers = []) :: HTTP.Response
     has_loadfile    = !isnothing(loadfile)
     content         = has_loadfile ? loadfile(filepath) : read(open(filepath), String)
     content_length  = has_loadfile ? string(sizeof(content)) : string(filesize(filepath))
     content_type    = mime_from_path(filepath, MIME"application/octet-stream"()) |> contenttype_from_mime
     push!(headers, "Content-Type" => content_type, "Content-Length" => content_length)
-    return HTTP.Response(status, headers, body = content) |> Renderer
+    return HTTP.Response(status, headers, body = content)
 end

--- a/src/utilities/render.jl
+++ b/src/utilities/render.jl
@@ -6,96 +6,90 @@ using MIMEs
 export html, text, json, xml, js, css, binary, file
 
 """
-    html(content::String; status::Int, headers::Vector{Pair})
+    html(content::String; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as HTML
 """
 function html(content::String; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "text/html; charset=utf-8",
-        "Content-Length" => string(sizeof(content))
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "text/html; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
+
 """
-    text(content::String; status::Int, headers::Vector{Pair})
+    text(content::String; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as plain text
 """
 function text(content::String; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "text/plain; charset=utf-8",
-        "Content-Length" => string(sizeof(content))
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "text/plain; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
 """
-    json(content::Any; status::Int, headers::Vector{Pair})
+    json(content::Any; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as JSON
 """
 function json(content::Any; status = 200, headers = []) :: HTTP.Response
     body = JSON3.write(content)
-    push!(headers, 
-        "Content-Type" => "application/json; charset=utf-8",
-        "Content-Length" => string(sizeof(body))
-    )
-    return HTTP.Response(status, headers, body = body)
+    response = HTTP.Response(status, headers, body = body)
+    HTTP.setheader(response, "Content-Type" => "application/json; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(body)))
+    return response
 end
 
 """
-    xml(content::String; status::Int, headers::Vector{Pair})
+    xml(content::String; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as XML
 """
 function xml(content::String; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "application/xml; charset=utf-8",
-        "Content-Length" => string(sizeof(content))
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "application/xml; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
 """
-    js(content::String; status::Int, headers::Vector{Pair})
+    js(content::String; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as JavaScript
 """
 function js(content::String; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "application/javascript; charset=utf-8",
-        "Content-Length" => string(sizeof(content))
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "application/javascript; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
 
 """
-    css(content::String; status::Int, headers::Vector{Pair})
+    css(content::String; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a String that should be interpreted as CSS
 """
 function css(content::String; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "text/css; charset=utf-8",
-        "Content-Length" => string(sizeof(content)), 
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "text/css; charset=utf-8")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
 """
-    binary(content::Vector{UInt8}; status::Int, headers::Vector{Pair})
+    binary(content::Vector{UInt8}; status::Int, headers::Vector{Pair}) :: HTTP.Response
 
 A convenience function to return a Vector of UInt8 that should be interpreted as binary data
 """
 function binary(content::Vector{UInt8}; status = 200, headers = []) :: HTTP.Response
-    push!(headers, 
-        "Content-Type" => "application/octet-stream",
-        "Content-Length" => string(sizeof(content))
-    )
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => "application/octet-stream")
+    HTTP.setheader(response, "Content-Length" => string(sizeof(content)))
+    return response
 end
 
 
@@ -119,6 +113,9 @@ function file(filepath::String; loadfile = nothing, status = 200, headers = []) 
     content         = has_loadfile ? loadfile(filepath) : read(open(filepath), String)
     content_length  = has_loadfile ? string(sizeof(content)) : string(filesize(filepath))
     content_type    = mime_from_path(filepath, MIME"application/octet-stream"()) |> contenttype_from_mime
-    push!(headers, "Content-Type" => content_type, "Content-Length" => content_length)
-    return HTTP.Response(status, headers, body = content)
+    response = HTTP.Response(status, headers, body = content)
+    HTTP.setheader(response, "Content-Type" => content_type)
+    HTTP.setheader(response, "Content-Length" => content_length)
+    return response
 end
+

--- a/test/rendertests.jl
+++ b/test/rendertests.jl
@@ -57,4 +57,31 @@ using .Oxygen
     end
 end
 
+@testset "Repeated calls do not duplicate headers" begin
+    response1 = css("body { background-color: #f0f0f0; }")
+    response2 = css("body { background-color: #f0f0f0; }")
+    @test Dict(response1.headers)["Content-Type"] == "text/css; charset=utf-8"
+    @test Dict(response2.headers)["Content-Type"] == "text/css; charset=utf-8"
+    @test length(response1.headers) == length(response2.headers)
+
+    response1 = binary(UInt8[72, 101, 108, 108, 111])  # "Hello" in ASCII
+    response2 = binary(UInt8[72, 101, 108, 108, 111])  # "Hello" in ASCII
+    @test Dict(response1.headers)["Content-Type"] == "application/octet-stream"
+    @test Dict(response2.headers)["Content-Type"] == "application/octet-stream"
+    @test length(response1.headers) == length(response2.headers) == 2
+end
+
+@testset "Repeated calls do not duplicate headers for file renderer" begin
+    response1 = file("content/index.html")
+    response2 = file("content/index.html")
+
+    @test findfirst(x -> x == ("Content-Type" => "text/html; charset=utf-8"), response1.headers) !== nothing
+    @test findfirst(x -> x == ("Content-Type" => "text/html; charset=utf-8"), response2.headers) !== nothing
+
+    count1 = length(response1.headers)
+    count2 = length(response2.headers)
+
+    @test count1 == count2 == 2
+end
+
 end

--- a/test/rendertests.jl
+++ b/test/rendertests.jl
@@ -8,52 +8,52 @@ using .Oxygen
 @testset "Render Module Tests" begin
 
     @testset "html function" begin
-        renderer = html("<h1>Hello, World!</h1>")
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "<h1>Hello, World!</h1>"
-        @test Dict(renderer.response.headers)["Content-Type"] == "text/html; charset=utf-8"
+        response = html("<h1>Hello, World!</h1>")
+        @test response.status == 200
+        @test text(response) == "<h1>Hello, World!</h1>"
+        @test Dict(response.headers)["Content-Type"] == "text/html; charset=utf-8"
     end
 
     @testset "text function" begin
-        renderer = text("Hello, World!")
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "Hello, World!"
-        @test Dict(renderer.response.headers)["Content-Type"] == "text/plain; charset=utf-8"
+        response = text("Hello, World!")
+        @test response.status == 200
+        @test text(response) == "Hello, World!"
+        @test Dict(response.headers)["Content-Type"] == "text/plain; charset=utf-8"
     end
 
     @testset "json function" begin
-        renderer = json(Dict("message" => "Hello, World!"))
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "{\"message\":\"Hello, World!\"}"
-        @test Dict(renderer.response.headers)["Content-Type"] == "application/json; charset=utf-8"
+        response = json(Dict("message" => "Hello, World!"))
+        @test response.status == 200
+        @test text(response) == "{\"message\":\"Hello, World!\"}"
+        @test Dict(response.headers)["Content-Type"] == "application/json; charset=utf-8"
     end
 
     @testset "xml function" begin
-        renderer = xml("<message>Hello, World!</message>")
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "<message>Hello, World!</message>"
-        @test Dict(renderer.response.headers)["Content-Type"] == "application/xml; charset=utf-8"
+        response = xml("<message>Hello, World!</message>")
+        @test response.status == 200
+        @test text(response) == "<message>Hello, World!</message>"
+        @test Dict(response.headers)["Content-Type"] == "application/xml; charset=utf-8"
     end
 
     @testset "js function" begin
-        renderer = js("console.log('Hello, World!');")
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "console.log('Hello, World!');"
-        @test Dict(renderer.response.headers)["Content-Type"] == "application/javascript; charset=utf-8"
+        response = js("console.log('Hello, World!');")
+        @test response.status == 200
+        @test text(response) == "console.log('Hello, World!');"
+        @test Dict(response.headers)["Content-Type"] == "application/javascript; charset=utf-8"
     end
 
     @testset "css function" begin
-        renderer = css("body { background-color: #f0f0f0; }")
-        @test renderer.response.status == 200
-        @test text(renderer.response) == "body { background-color: #f0f0f0; }"
-        @test Dict(renderer.response.headers)["Content-Type"] == "text/css; charset=utf-8"
+        response = css("body { background-color: #f0f0f0; }")
+        @test response.status == 200
+        @test text(response) == "body { background-color: #f0f0f0; }"
+        @test Dict(response.headers)["Content-Type"] == "text/css; charset=utf-8"
     end
 
     @testset "binary function" begin
-        renderer = binary(UInt8[72, 101, 108, 108, 111])  # "Hello" in ASCII
-        @test renderer.response.status == 200
-        @test renderer.response.body == UInt8[72, 101, 108, 108, 111]
-        @test Dict(renderer.response.headers)["Content-Type"] == "application/octet-stream"
+        response = binary(UInt8[72, 101, 108, 108, 111])  # "Hello" in ASCII
+        @test response.status == 200
+        @test response.body == UInt8[72, 101, 108, 108, 111]
+        @test Dict(response.headers)["Content-Type"] == "application/octet-stream"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,9 +27,6 @@ struct Book
     author::String
 end
 
-function unwrap(renderer::Oxygen.Util.Renderer) :: String
-    return String(renderer.response.body)
-end
     
 localhost = "http://127.0.0.1:8080"
 
@@ -506,23 +503,23 @@ r = internalrequest(HTTP.Request("GET", "/static/test.txt"))
 body = text(r)
 @test r.status == 200
 @test Dict(r.headers)["Content-Type"] == "text/plain; charset=utf-8"
-@test body == file("content/test.txt") |> unwrap
+@test body == file("content/test.txt") |> text
 @test body == "this is a sample text file"
 
 r = internalrequest(HTTP.Request("GET", "/static/sample.html"))
 @test r.status == 200
 @test Dict(r.headers)["Content-Type"] == "text/html; charset=utf-8"
-@test text(r) == file("content/sample.html") |> unwrap
+@test text(r) == file("content/sample.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/static/index.html"))
 @test r.status == 200
 @test Dict(r.headers)["Content-Type"] == "text/html; charset=utf-8"
-@test text(r) == file("content/index.html") |> unwrap
+@test text(r) == file("content/index.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/static/"))
 @test r.status == 200
 @test Dict(r.headers)["Content-Type"] == "text/html; charset=utf-8"
-@test text(r) == file("content/index.html") |> unwrap
+@test text(r) == file("content/index.html") |> text
 
 
 # Body transformation tests
@@ -553,15 +550,15 @@ person = json(r, Person)
 
 r = internalrequest(HTTP.Request("GET", "/file"))
 @test r.status == 200
-@test text(r) == file("content/sample.html") |> unwrap
+@test text(r) == file("content/sample.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/dynamic/sample.html"))
 @test r.status == 200
-@test text(r) == file("content/sample.html") |> unwrap
+@test text(r) == file("content/sample.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/static/sample.html"))
 @test r.status == 200
-@test text(r) == file("content/sample.html") |> unwrap
+@test text(r) == file("content/sample.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/multiply/a/8"))
 @test r.status == 500


### PR DESCRIPTION
1.) renderer functions will no longer append duplicate headers
2.) default error response is now returned as json instead of plain text
3.) removed redundant error handling blocks in the streamutil module
2.) removed the Renderer struct and am now returning HTTP.Response objects directly