### PR TITLE
Improve get() method shadowing

### DIFF
--- a/src/Oxygen.jl
+++ b/src/Oxygen.jl
@@ -4,14 +4,13 @@ include("core.jl"); using .Core
 include("instances.jl"); using .Instances
 include("extensions/load.jl");
 
-import HTTP: Request, Response
+using HTTP: Request, Response, Stream, WebSocket
 using .Core: Context, History, Server, Nullable
 using .Core: GET, POST, PUT, DELETE, PATCH
 
-
 const CONTEXT = Ref{Context}(Context())
 
-import Base: get 
+import Base: get
 include("methods.jl")
 include("deprecated.jl")
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -230,6 +230,7 @@ websocket(func::Function, path::Function)  = route([WEBSOCKET], path, func)
 
 ### Core Routing Functions Support for do..end Syntax ###
 
+get(collection, key, default)           = Base.get(collection, key, default) # pass through other get calls to base.get()
 get(func::Function, path::String)       = route([GET], path, func)
 get(func::Function, path::Function)     = route([GET], path, func)
 
@@ -245,15 +246,13 @@ patch(func::Function, path::Function)   = route([PATCH], path, func)
 delete(func::Function, path::String)    = route([DELETE], path, func)
 delete(func::Function, path::Function)  = route([DELETE], path, func)
 
-
-
 """
     @staticfiles(folder::String, mountdir::String, headers::Vector{Pair{String,String}}=[])
 
 Mount all files inside the /static folder (or user defined mount point)
 """
 macro staticfiles(folder, mountdir="static", headers=[])
-    printstyled("@staticfiles macro is deprecated, please use the staticfiles() function instead\n", color = :red, bold = true) 
+    printstyled("@staticfiles macro is deprecated, please use the staticfiles() fu``nction instead\n", color = :red, bold = true) 
     quote
         staticfiles($(esc(folder)), $(esc(mountdir)); headers=$(esc(headers))) 
     end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -252,7 +252,7 @@ delete(func::Function, path::Function)  = route([DELETE], path, func)
 Mount all files inside the /static folder (or user defined mount point)
 """
 macro staticfiles(folder, mountdir="static", headers=[])
-    printstyled("@staticfiles macro is deprecated, please use the staticfiles() fu``nction instead\n", color = :red, bold = true) 
+    printstyled("@staticfiles macro is deprecated, please use the staticfiles() function instead\n", color = :red, bold = true) 
     quote
         staticfiles($(esc(folder)), $(esc(mountdir)); headers=$(esc(headers))) 
     end

--- a/test/oxidise.jl
+++ b/test/oxidise.jl
@@ -5,13 +5,11 @@ using HTTP
 using ..Constants
 using Oxygen; @oxidise
 
-PORT = 6060
-
 @get "/test" function(req)
     return "Hello World"
 end
 
-serve(port=PORT, host=HOST, async=true,  show_errors=false, show_banner=false)
+serve(port=PORT, async=true,  show_errors=false, show_banner=false)
 
 r = internalrequest(HTTP.Request("GET", "/test"))
 @test r.status == 200

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ include("handlertests.jl")
 
 #### Core Tests ####
 
+include("shadowingtests.jl")
 include("metricstests.jl")
 include("routingfunctionstests.jl")
 include("rendertests.jl")

--- a/test/shadowingtests.jl
+++ b/test/shadowingtests.jl
@@ -62,20 +62,24 @@ end
 end
 
 
-# Define a new custom struct
-struct MyStruct
-    data::Dict{String, String}
-end
+@testset "Test attaching new get() method to a custom struct" begin
 
-# Override the Base.get method for MyStruct
-Base.get(mystruct::MyStruct, key, default) = get(mystruct.data, key, default)
+    # Define a new custom struct
+    struct MyStruct
+        data::Dict{String, String}
+    end
 
-# Add a test to call the new get method
-@testset "Base.get tests for MyStruct" begin
-    mystruct = MyStruct(Dict("key1" => "value1", "key2" => "value2"))
-    @test get(mystruct, "key1", "default") == "value1"
-    @test get(mystruct, "key2", "default") == "value2"
-    @test get(mystruct, "key3", "default") == "default"
+    # Override the Base.get method for MyStruct
+    Base.get(mystruct::MyStruct, key, default) = get(mystruct.data, key, default)
+
+    # Add a test to call the new get method
+    @testset "Base.get tests for MyStruct" begin
+        mystruct = MyStruct(Dict("key1" => "value1", "key2" => "value2"))
+        @test get(mystruct, "key1", "default") == "value1"
+        @test get(mystruct, "key2", "default") == "value2"
+        @test get(mystruct, "key3", "default") == "default"
+    end
+
 end
 
 end

--- a/test/shadowingtests.jl
+++ b/test/shadowingtests.jl
@@ -62,7 +62,7 @@ end
 end
 
 
-@testset "Test attaching new get() method to a custom struct" begin
+@testset "Base.get tests for MyStruct" begin
 
     # Define a new custom struct
     struct MyStruct
@@ -72,14 +72,11 @@ end
     # Override the Base.get method for MyStruct
     Base.get(mystruct::MyStruct, key, default) = get(mystruct.data, key, default)
 
-    # Add a test to call the new get method
-    @testset "Base.get tests for MyStruct" begin
-        mystruct = MyStruct(Dict("key1" => "value1", "key2" => "value2"))
-        @test get(mystruct, "key1", "default") == "value1"
-        @test get(mystruct, "key2", "default") == "value2"
-        @test get(mystruct, "key3", "default") == "default"
-    end
-
+    mystruct = MyStruct(Dict("key1" => "value1", "key2" => "value2"))
+    @test get(mystruct, "key1", "default") == "value1"
+    @test get(mystruct, "key2", "default") == "value2"
+    @test get(mystruct, "key3", "default") == "default"
+    
 end
 
 end

--- a/test/shadowingtests.jl
+++ b/test/shadowingtests.jl
@@ -1,0 +1,81 @@
+module ShadowingTests
+using Test
+using Oxygen; @oxidise
+
+get("/") do 
+    text("Hello World")
+end
+
+get("/add/{a}/{b}") do req, a::Int, b::Int
+    text("$(a + b)")
+end
+
+@testset "Oxygen.get routing function tests" begin
+    r = internalrequest(Request("GET", "/"))
+    @test r.status == 200
+    @test text(r) == "Hello World"
+    
+    r = internalrequest(Request("GET", "/add/3/7"))
+    @test r.status == 200
+    @test text(r) == "10"
+end
+
+@testset "Base.get dict tests" begin
+    # Tests for Dictionaries
+    dict = Dict("key1" => "value1", "key2" => "value2")
+    @test get(dict, "key1", nothing) == "value1"
+    @test get(dict, "key2", nothing) == "value2"
+    @test get(dict, "key3", nothing) === nothing
+end
+
+
+@testset "Base.get callable tests" begin
+    dict = Dict("key1" => "value1", "key2" => "value2")
+    @test get(() -> "default", dict, "key1") == "value1"
+    @test get(() -> "default", dict, "key3") == "default"
+    @test get(() -> "another default", dict, "key4") == "another default"
+    @test get(() -> 42, dict, "key5") == 42
+end
+
+@testset "Base.get callable tests with do syntax" begin
+    dict = Dict("key1" => "value1", "key2" => "value2")
+
+    @test get(dict, "key1") do
+        "default"
+    end == "value1"
+
+    @test get(dict, "key2") do
+        "default"
+    end == "value2"
+
+    @test get(dict, "key3") do
+        "default"
+    end == "default"
+
+    @test get(dict, "key4") do
+        "another default"
+    end == "another default"
+
+    @test get(dict, "key5") do
+        42
+    end == 42
+end
+
+
+# Define a new custom struct
+struct MyStruct
+    data::Dict{String, String}
+end
+
+# Override the Base.get method for MyStruct
+Base.get(mystruct::MyStruct, key, default) = get(mystruct.data, key, default)
+
+# Add a test to call the new get method
+@testset "Base.get tests for MyStruct" begin
+    mystruct = MyStruct(Dict("key1" => "value1", "key2" => "value2"))
+    @test get(mystruct, "key1", "default") == "value1"
+    @test get(mystruct, "key2", "default") == "value2"
+    @test get(mystruct, "key3", "default") == "default"
+end
+
+end


### PR DESCRIPTION
- Added a default get() function to pass through other calls to the Base.get function