### PR TITLE
Bonito connection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [weakdeps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
@@ -35,7 +36,7 @@ TimeZonesExt = "TimeZones"
 WGLMakieExt = ["WGLMakie", "Bonito"]
 
 [compat]
-Bonito = "^4"
+Bonito = "^4.0.1"
 CairoMakie = "^0.13"
 DataStructures = "^0.18.15"
 Dates = "^1"
@@ -63,4 +64,4 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Bonito", "CairoMakie", "Mustache", "OteraEngine", "ProtoBuf", "Pkg", "StructTypes", "Suppressor", "Test", "TimeZones", "WGLMakie"]
+test = ["Base64", "Bonito", "CairoMakie", "Mustache", "OteraEngine", "ProtoBuf", "Pkg", "StructTypes", "Suppressor", "Test", "TimeZones", "WGLMakie"]

--- a/demo/bonitoconnectiondemo.jl
+++ b/demo/bonitoconnectiondemo.jl
@@ -1,0 +1,46 @@
+using Bonito
+using Oxygen
+using HTTP
+using WGLMakie
+
+
+@get "/" function(req::HTTP.Request)
+    app = App() do
+        xs = Observable([0])
+        ys = Observable([0])
+        counter = Observable(0)
+        @async begin
+            while true
+                sleep(1)
+                cur_xs = xs[]
+                cur_ys = ys[]
+                push!(cur_xs, cur_xs[end] + 1)
+                push!(cur_ys, counter[])
+                if length(cur_xs) > 10
+                    popfirst!(cur_xs)
+                    popfirst!(cur_ys)
+                end
+                notify(xs)
+                notify(ys)
+            end
+        end
+        button = Bonito.Button("increment")
+        on(button.value) do click::Bool
+            counter[] += 1
+        end
+        f = Figure()
+        ax = Axis(f[1, 1])
+        lines!(ax, xs, ys)
+        on(ys) do _
+            WGLMakie.autolimits!(ax)
+            return nothing
+        end
+        DOM.div(DOM.h2(counter), button, DOM.div(f))
+    end
+    return Oxygen.html(app)
+end
+
+
+Oxygen.setup_bonito_connection(Oxygen.CONTEXT[]; setup_all=true)
+
+serve()

--- a/demo/bonitoconnectiondemo.jl
+++ b/demo/bonitoconnectiondemo.jl
@@ -41,6 +41,6 @@ using WGLMakie
 end
 
 
-Oxygen.setup_bonito_connection(Oxygen.CONTEXT[]; setup_all=true)
+Oxygen.setup_bonito_connection(; setup_all=true)
 
 serve()

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -941,7 +941,7 @@ There are two parts to integrating Bonito with Oxygen:
 To do both you can simply use the following command at the top level of your module or script:
 
 ```julia
-Oxygen.setup_bonito_connection(CONTEXT[]; setup_all=true)
+Oxygen.setup_bonito_connection(; setup_all=true)
 ```
 
 In case you want to change the url of the Bonito websocket route, you can do so via the `route_base` keyword argument, which defaults to `"/bonito_websocket/"`.
@@ -951,7 +951,7 @@ You may like to add some custom behaviour to the route such as authentication. I
 ```julia
 function __init__()
     const route_base = "/foobar/"
-    oxygen_bonito = Oxygen.setup_bonito_connection(CONTEXT[]; setup_register_connection=true, route_base=route_base)
+    oxygen_bonito = Oxygen.setup_bonito_connection(; setup_register_connection=true, route_base=route_base)
     route_pattern = route_base * "{session_id}"
     @websocket route_pattern function mybonitohandler(websocket::HTTP.WebSocket, session_id::String)
         # Add custom behaviour here

--- a/ext/BonitoExt.jl
+++ b/ext/BonitoExt.jl
@@ -11,9 +11,9 @@ const HTML  = MIME"text/html"()
 """
 Converts a Figure object to the designated MIME type and wraps it inside an HTTP response.
 """
-function response(content::App, mime_type::MIME, status::Int, headers::Vector)
+function response(content::App, mime_type::MIME, status::Int, headers::Vector, offline=Oxygen.BONITO_OFFLINE[])
     # Force inlining all data & js dependencies
-    Page(exportable=true, offline=true)
+    Page(exportable=true, offline=offline)
 
     # Convert & load the figure into an IOBuffer
     io = IOBuffer()
@@ -32,6 +32,8 @@ end
 
 Convert a Bonito.App to HTML and wrap it inside an HTTP response.
 """
-html(app::App, status=200, headers=[]) :: HTTP.Response = response(app, HTML, status, headers)
+html(app::App, status=200, headers=[], offline=Oxygen.BONITO_OFFLINE[]) :: HTTP.Response = response(app, HTML, status, headers, offline)
+
+include("./bonito/connection.jl")
 
 end

--- a/ext/WGLMakieExt.jl
+++ b/ext/WGLMakieExt.jl
@@ -1,7 +1,7 @@
 module WGLMakieExt
 
 import HTTP
-import Oxygen: html # import the html function from util so we can override it
+import Oxygen: html, BONITO_OFFLINE # import the html function from util so we can override it
 import Bonito: Page
 import WGLMakie.Makie: FigureLike
 
@@ -12,9 +12,9 @@ const HTML  = MIME"text/html"()
 """
 Converts a Figure object to the designated MIME type and wraps it inside an HTTP response.
 """
-function response(content::FigureLike, mime_type::MIME, status::Int, headers::Vector)
+function response(content::FigureLike, mime_type::MIME, status::Int, headers::Vector, offline=BONITO_OFFLINE[])
     # Force inlining all data & js dependencies
-    Page(exportable=true, offline=true)
+    Page(exportable=true, offline=offline)
 
     # Convert & load the figure into an IOBuffer
     io = IOBuffer()
@@ -34,6 +34,6 @@ end
 
 Convert a Makie figure to HTML and wrap it inside an HTTP response.
 """
-html(fig::FigureLike, status=200, headers=[]) :: HTTP.Response = response(fig, HTML, status, headers)
+html(fig::FigureLike, status=200, headers=[], offline=BONITO_OFFLINE[]) :: HTTP.Response = response(fig, HTML, status, headers, offline)
 
 end

--- a/ext/bonito/connection.jl
+++ b/ext/bonito/connection.jl
@@ -1,0 +1,164 @@
+using HTTP.WebSockets: WebSocket, WebSocketError
+using HTTP.WebSockets: receive, isclosed
+using HTTP.WebSockets
+
+using Oxygen: Oxygen
+using Bonito: Bonito
+using Bonito: FrontendConnection, WebSocketHandler, Session, setup_websocket_connection_js
+using Bonito: run_connection_loop, register_connection!
+using Bonito: CleanupPolicy, DefaultCleanupPolicy, allow_soft_close, soft_close, should_cleanup
+
+mutable struct OxygenWebSocketConnection <: FrontendConnection
+    context::Oxygen.ServerContext
+    endpoint::String
+    session::Union{Nothing,Session}
+    handler::WebSocketHandler
+end
+
+function OxygenWebSocketConnection(context::Oxygen.ServerContext, endpoint::String)
+    return OxygenWebSocketConnection(context, endpoint, nothing, WebSocketHandler())
+end
+
+Base.isopen(ws::OxygenWebSocketConnection) = isopen(ws.handler)
+Base.write(ws::OxygenWebSocketConnection, binary) = write(ws.handler, binary)
+Base.close(ws::OxygenWebSocketConnection) = close(ws.handler)
+
+mutable struct BonitoConnectionContext
+    cleanup_policy::CleanupPolicy
+    open_connections::Dict{String, OxygenWebSocketConnection}
+    cleanup_task::Union{Task, Nothing}
+    lock::ReentrantLock
+end
+
+BonitoConnectionContext(policy=DefaultCleanupPolicy()) = BonitoConnectionContext(policy, Dict{String, Session{OxygenWebSocketConnection}}(), nothing, ReentrantLock())
+
+"""
+    setup_bonito_connection(
+        context::Context;
+        setup_all=false,
+        setup_route=setup_all,
+        setup_register_connection=setup_all,
+        route_base="/bonito_websocket/"
+    )
+
+This is the high level function to setup bonito connection. It will register the route and create a connection if needed.
+
+In the simplest use case you can simply pass `setup_bonito_connection(CONTEXT[]; setup_all=true)` and it will set up everything for you. Please see the guide for advanced usage.
+"""
+function Oxygen.setup_bonito_connection(
+    context::Oxygen.ServerContext;
+    setup_all=false,
+    setup_route=setup_all,
+    setup_register_connection=setup_all,
+    route_base="/bonito-websocket/"
+)
+    Oxygen.BONITO_OFFLINE[] = false
+    Oxygen.install_ext_context(
+        context,
+        bonito_connection = BonitoConnectionContext()
+    )
+    handler = Oxygen.mk_bonito_websocket_handler(context)
+    if setup_route
+        Oxygen.Core.register(context, Oxygen.WEBSOCKET, route_base * "{session_id}", handler)
+    end
+    function mk_connection()
+        return OxygenWebSocketConnection(context, route_base)
+    end
+    if setup_register_connection
+        register_connection!(mk_connection, OxygenWebSocketConnection)
+    end
+    return (;
+        mk_connection,
+        handler
+    )
+end
+
+
+function Oxygen.mk_bonito_websocket_handler(context::Oxygen.ServerContext)
+    if !(haskey(context.ext_context[], :bonito_connection))
+        error("bonito_connection not setup in context (did you call setup_bonito_connection(...)?)")
+    end
+    bonito_context = context.ext_context[].bonito_connection
+    function bonito_websocket_handler(websocket::HTTP.WebSocket, session_id::String)
+        local connection
+        lock(bonito_context.lock) do
+            connection = bonito_context.open_connections[session_id]
+        end
+        session = connection.session
+        handler = connection.handler
+
+        @debug("opening ws connection for session: $(session.id)")
+        try
+            run_connection_loop(session, handler, websocket)
+        finally
+            if allow_soft_close(bonito_context.cleanup_policy)
+                @debug("Soft closing: $(session.id)")
+                soft_close(session)
+            else
+                @debug("Closing: $(session.id)")
+                # might as well close it immediately
+                close(session)
+                lock(bonito_context.lock) do
+                    delete!(bonito_context.open_connections, session.id)
+                end
+            end
+        end
+    end
+    return bonito_websocket_handler
+end
+
+function cleanup_bonito_context(bonito_context)
+    remove = Set{OxygenWebSocketConnection}()
+    lock(bonito_context.lock) do
+        for (session_id, connection) in bonito_context.open_connections
+            if should_cleanup(bonito_context.cleanup_policy, connection.session)
+                push!(remove, connection)
+            end
+        end
+        for connection in remove
+            if !isnothing(connection.session)
+                session = connection.session
+                delete!(bonito_context.open_connections, session.id)
+                close(session)
+            end
+        end
+    end
+end
+
+function cleanup_loop(bonito_context)
+    while true
+        try
+            sleep(1)
+            cleanup_bonito_context(bonito_context)
+        catch e
+            if !(e isa EOFError)
+                @warn "error while cleaning up server" exception=(e, Base.catch_backtrace())
+            end
+        end
+    end
+end
+
+function Bonito.setup_connection(session::Session, connection::OxygenWebSocketConnection)
+    connection.session = session
+    context = connection.context
+    if !(:bonito_connection in keys(context.ext_context[]))
+        error("bonito_connection not setup in context (did you call setup_bonito_connection(...)?)")
+    end
+    bonito_context = context.ext_context[].bonito_connection
+    if context.service.external_url[] === nothing
+        error("external_url not set in context (did you call start the server yet?)")
+    end
+    external_url_base = context.service.external_url[]
+    lock(bonito_context.lock) do
+        if bonito_context.cleanup_task === nothing
+            bonito_context.cleanup_task = Threads.@spawn cleanup_loop(bonito_context)
+        end
+        bonito_context.open_connections[session.id] = connection
+    end
+    external_url = external_url_base * session.connection.endpoint
+    return setup_websocket_connection_js(external_url, session)
+end
+
+function Bonito.setup_connection(session::Session{OxygenWebSocketConnection})
+    return Bonito.setup_connection(session, session.connection)
+end

--- a/ext/bonito/connection.jl
+++ b/ext/bonito/connection.jl
@@ -34,7 +34,7 @@ BonitoConnectionContext(policy=DefaultCleanupPolicy()) = BonitoConnectionContext
 
 """
     setup_bonito_connection(
-        context::Context;
+        [context::ServerContext];
         setup_all=false,
         setup_route=setup_all,
         setup_register_connection=setup_all,
@@ -43,7 +43,7 @@ BonitoConnectionContext(policy=DefaultCleanupPolicy()) = BonitoConnectionContext
 
 This is the high level function to setup bonito connection. It will register the route and create a connection if needed.
 
-In the simplest use case you can simply pass `setup_bonito_connection(CONTEXT[]; setup_all=true)` and it will set up everything for you. Please see the guide for advanced usage.
+In the simplest use case you can simply pass `setup_bonito_connection(; setup_all=true)` and it will set up everything for you. Please see the guide for advanced usage.
 """
 function Oxygen.setup_bonito_connection(
     context::Oxygen.ServerContext;

--- a/src/context.jl
+++ b/src/context.jl
@@ -5,7 +5,7 @@ using HTTP
 using HTTP: Server, Router
 using ..Types
 
-export ServerContext, CronContext, TasksContext, Documenation, EagerReviseService, Service, history, wait, close, isopen
+export ServerContext, CronContext, TasksContext, Documenation, EagerReviseService, Service, history, wait, close, isopen, install_ext_context
 
 function defaultSchema() :: Dict
     Dict(
@@ -68,6 +68,14 @@ end
     tasks   :: TasksContext     = TasksContext()
     mod     :: Nullable{Module} = nothing
     app_context :: Ref{Any}     = Ref{Any}(missing) # This stores a reference to an Context{T} object
+    ext_context :: Ref{Any}     = Ref{Any}((;)) # This stores a reference to a namedtuple
+end
+
+function install_ext_context(ctx::ServerContext; kwargs...)
+    ctx.ext_context[] = (;
+        ctx.ext_context[]...,
+        kwargs...
+    )
 end
 
 Base.isopen(service::Service)   = !isnothing(service.server[]) && isopen(service.server[])

--- a/src/exts.jl
+++ b/src/exts.jl
@@ -5,6 +5,7 @@ This module holds all the partial function & struct definitions for all package 
 export ProtoBuffer, protobuf
 export mustache, otera
 export png, svg, pdf
+export setup_bonito_connection, mk_bonito_websocket_handler
 
 # Serialization extension definitions
 function protobuf end
@@ -20,3 +21,8 @@ function otera end
 function png end
 function svg end
 function pdf end
+
+# Bonito extension definitions
+function setup_bonito_connection end
+function mk_bonito_websocket_handler end
+const BONITO_OFFLINE::Ref{Bool} = Ref(true)

--- a/src/exts_methods.jl
+++ b/src/exts_methods.jl
@@ -1,0 +1,5 @@
+# This file is where extension methods are coupled to global state
+
+function setup_bonito_connection(; kwargs...)
+    Oxygen.setup_bonito_connection(CONTEXT[]; kwargs...)
+end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -392,3 +392,4 @@ for method in [:startcronjobs, :stopcronjobs, :clearcronjobs]
     end)
 end
 
+include("./exts_methods.jl")

--- a/test/extensions/bonitotests.jl
+++ b/test/extensions/bonitotests.jl
@@ -72,7 +72,7 @@ end
         html(app)
     end
 
-    setup_bonito_connection(CONTEXT[]; setup_all=true)
+    setup_bonito_connection(; setup_all=true)
 
     serve(host=HOST, port=PORT, async=true, show_banner=false, access_log=nothing)
 

--- a/test/extensions/bonitotests.jl
+++ b/test/extensions/bonitotests.jl
@@ -1,4 +1,5 @@
-module CairoMakieTests
+module BonitoTests
+using Base64
 using HTTP
 using Test
 using Bonito
@@ -55,6 +56,72 @@ end
     @test r.status == 200
     @test HTTP.header(r, "Content-Type") == "text/html"
     @test parse(Int, HTTP.header(r, "Content-Length")) >= 0
+    terminate()
+end
+
+@testset "Bonito websocket connection tests" begin
+    get("/connection") do
+        app = App() do
+            counter = Observable(0)
+            button = Bonito.Button("increment")
+            on(button.value) do click::Bool
+                counter[] += 1
+            end
+            DOM.div(DOM.h2(counter), button)
+        end
+        html(app)
+    end
+
+    setup_bonito_connection(CONTEXT[]; setup_all=true)
+
+    serve(host=HOST, port=PORT, async=true, show_banner=false, access_log=nothing)
+
+    # Test overloaded text() function
+    r = HTTP.get("$localhost/connection")
+    @test r.status == 200
+    @test HTTP.header(r, "Content-Type") == "text/html"
+    @test parse(Int, HTTP.header(r, "Content-Length")) >= 0
+
+    scripts_regex = r"src=\"data:application/javascript;base64,([^\"]+)\""
+    base64_scripts = [match[1] for match in eachmatch(scripts_regex, String(r.body))]
+    @test length(base64_scripts) >= 1
+    sort!(base64_scripts; by=length)
+
+    ws_regex = r"WS.setup_connection\(([^)]+)\)"s
+
+    ws_args = nothing
+    for script in base64_scripts
+        script = String(base64decode(script))
+        ws_match = match(ws_regex, script)
+        if ws_match != nothing
+            ws_args = ws_match[1]
+            ws_args = replace(ws_args, r"[\"'{}\s]+" => "")
+            ws_args = split(ws_args, ",")
+            new_ws_args = Dict()
+            for arg in ws_args
+                bits = split(arg, ":"; limit=2)
+                new_ws_args[String(strip(bits[1]))] = String(strip(bits[2]))
+            end
+            ws_args = new_ws_args
+            break
+        end
+    end
+    @test ws_args != nothing
+    @test "proxy_url" in keys(ws_args)
+    @test "session_id" in keys(ws_args)
+    @test ws_args["proxy_url"] == "$localhost/bonito-websocket/"
+    session_id = ws_args["session_id"]
+
+    websocket_url = "$localhost/bonito-websocket/$session_id"
+    websocket_url = replace(websocket_url, "http" => "ws")
+    saved_ws = nothing
+    WebSockets.open(websocket_url) do ws
+        saved_ws = ws
+    end
+    @test saved_ws !== nothing
+    @test saved_ws.response.status == 101
+    @test WebSockets.isclosed(saved_ws)
+
     terminate()
 end
 


### PR DESCRIPTION
This incorporates https://github.com/OxygenFramework/Oxygen.jl/pull/211

Currently if you use WGLMakie/Bonito together with an interactive plot, Bonito will start a websocket server locally. It's nicer to have the endpoint managed by Oxygen so it's on the same port, can easily be put behind auth and so on.

Here's an example of how to use it

```
function __init__()
    @info "Setting up Bonito to use Oxygen websockets"
    @websocket "/bonito/{session_id}" Oxygen.bonito_websocket_handler
end

@get "/" function plot(req)
    WGLMakie.activate!()
    force_asset_server!(NoServer())
    force_connection!(Oxygen.OxygenWebSocketConnection(getexternalurl() * "/bonito/"))
    app = App() do session::Session
        # Plotting commands
    end
    app_html = sprint(io-> show(io, MIME"text/html"(), app))
end
```
This needs to be worked on a bit more. Better API, docs, tests, and also timeout management/session evication.

First I will open a ticket with Bonito to see which parts of the API are public in case it is possible to share more code.

Comments are welcome already though.