### PR TITLE
Upgrade to HTTP.jl 2.x

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: '1.11'
           arch: ${{ runner.arch }}
       - name: "Add the General registry via Git"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.11' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           # - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "Oxygen"
 uuid = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
+version = "1.10.2"
 authors = ["Nathan Ortega <nate.ortega95@gmail.com>"]
 repo = "https://github.com/OxygenFramework/Oxygen.jl.git"
-version = "1.10.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -16,6 +16,7 @@ RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [weakdeps]
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
@@ -36,11 +37,11 @@ TimeZonesExt = "TimeZones"
 WGLMakieExt = ["WGLMakie", "Bonito"]
 
 [compat]
-Bonito = "^4"
+Bonito = "^5"
 CairoMakie = "^0.13, 0.15"
 DataStructures = "^0.18.15, 0.19"
 Dates = "^1"
-HTTP = "^1.8"
+HTTP = "^2.4"
 JSON = "^1.3"
 LRUCache = "^1.6"
 MIMEs = "^1"
@@ -55,8 +56,9 @@ Statistics = "^1"
 StructTypes = "^1"
 Suppressor = "^0.2.6"
 TimeZones = "^1.20.0"
+URIs = "1.6.1"
 WGLMakie = "^0.11, 0.13"
-julia = "^1.10"
+julia = "^1.11"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ end
 end
 
 # Websocket Handler
-@websocket "/ws" function(ws::HTTP.WebSocket)
+@websocket "/ws" function(ws::HTTP.WebSockets.WebSocket)
     ...
 end
 ```
@@ -153,7 +153,7 @@ Stream handlers are used to stream data. They are defined using the `@stream` ma
 - You need to explicitly include the type definition so Oxygen can identify this as a `Stream` handler
 
 ### Websocket Handlers
-Websocket handlers are used to handle websocket connections. They are defined using the `@websocket` macro or the `websocket()` function and accept a `HTTP.WebSocket` object as the first argument. These handlers support both function and do-block syntax.
+Websocket handlers are used to handle websocket connections. They are defined using the `@websocket` macro or the `websocket()` function and accept a `HTTP.WebSockets.WebSocket` object as the first argument. These handlers support both function and do-block syntax.
 
 - `@websocket` and `websocket()` don't require a type definition on the first argument, they assume it's a websocket.
 - `Websocket` handlers can also be assigned with the `@get` macro or `get()` function, because the websocket protocol requires a `GET` request to initiate the handshake. 
@@ -1053,33 +1053,12 @@ dynamicfiles("content", "dynamic")
 # start the web server
 serve()
 ```
-## Performance Tips
-
-Disabling the internal logger can provide some massive performance gains, which can be helpful in some scenarios.
-Anecdotally, i've seen a 2-3x speedup in `serve()` and a 4-5x speedup in `serveparallel()` performance.
-
-```julia 
-# This is how you disable internal logging in both modes
-serve(access_log=nothing)
-serveparallel(access_log=nothing)
-```
-
 ## Logging
 
-Oxygen provides a default logging format but allows you to customize the format using the `access_log` parameter. This functionality is available in both the `serve()` and `serveparallel()` functions.
-
-You can read more about the logging options [here](https://juliaweb.github.io/HTTP.jl/stable/reference/#HTTP.@logfmt_str)
-
-```julia 
-# Uses the default logging format
-serve()
-
-# Customize the logging format 
-serve(access_log=logfmt"[$time_iso8601] \"$request\" $status")
-
-# Disable internal request logging 
-serve(access_log=nothing)
-```
+HTTP.jl 2.x no longer does per-request access logging in the server, so the `access_log` keyword
+(and the `logfmt"..."` format macro) from earlier Oxygen versions is gone. The `access_log` kwarg
+is still accepted by `serve()` and `serveparallel()` for backwards compatibility, but it is ignored.
+If you need request logging, add it yourself with a small [middleware](#middleware) function.
 
 ## Middleware
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -104,7 +104,7 @@ end
 end
 
 # Websocket Handler
-@websocket "/ws" function(ws::HTTP.WebSocket)
+@websocket "/ws" function(ws::HTTP.WebSockets.WebSocket)
     ...
 end
 ```
@@ -153,7 +153,7 @@ Stream handlers are used to stream data. They are defined using the `@stream` ma
 - You need to explicitly include the type definition so Oxygen can identify this as a `Stream` handler
 
 ### Websocket Handlers
-Websocket handlers are used to handle websocket connections. They are defined using the `@websocket` macro or the `websocket()` function and accept a `HTTP.WebSocket` object as the first argument. These handlers support both function and do-block syntax.
+Websocket handlers are used to handle websocket connections. They are defined using the `@websocket` macro or the `websocket()` function and accept a `HTTP.WebSockets.WebSocket` object as the first argument. These handlers support both function and do-block syntax.
 
 - `@websocket` and `websocket()` don't require a type definition on the first argument, they assume it's a websocket.
 - `Websocket` handlers can also be assigned with the `@get` macro or `get()` function, because the websocket protocol requires a `GET` request to initiate the handshake. 
@@ -1053,33 +1053,12 @@ dynamicfiles("content", "dynamic")
 # start the web server
 serve()
 ```
-## Performance Tips
-
-Disabling the internal logger can provide some massive performance gains, which can be helpful in some scenarios.
-Anecdotally, i've seen a 2-3x speedup in `serve()` and a 4-5x speedup in `serveparallel()` performance.
-
-```julia 
-# This is how you disable internal logging in both modes
-serve(access_log=nothing)
-serveparallel(access_log=nothing)
-```
-
 ## Logging
 
-Oxygen provides a default logging format but allows you to customize the format using the `access_log` parameter. This functionality is available in both the `serve()` and `serveparallel()` functions.
-
-You can read more about the logging options [here](https://juliaweb.github.io/HTTP.jl/stable/reference/#HTTP.@logfmt_str)
-
-```julia 
-# Uses the default logging format
-serve()
-
-# Customize the logging format 
-serve(access_log=logfmt"[$time_iso8601] \"$request\" $status")
-
-# Disable internal request logging 
-serve(access_log=nothing)
-```
+HTTP.jl 2.x no longer does per-request access logging in the server, so the `access_log` keyword
+(and the `logfmt"..."` format macro) from earlier Oxygen versions is gone. The `access_log` kwarg
+is still accepted by `serve()` and `serveparallel()` for backwards compatibility, but it is ignored.
+If you need request logging, add it yourself with a small [middleware](#middleware) function.
 
 ## Middleware
 
@@ -1110,7 +1089,7 @@ function CorsMiddleware(handler)
     return function(req::HTTP.Request)
         println("CORS middleware")
         # determine if this is a pre-flight request from the browser
-        if HTTP.method(req)=="OPTIONS"
+        if req.method=="OPTIONS"
             return HTTP.Response(200, CORS_HEADERS)  
         else 
             return handler(req) # passes the request to the AuthMiddleware

--- a/ext/ProtoBufExt.jl
+++ b/ext/ProtoBufExt.jl
@@ -21,12 +21,14 @@ Decode a protobuf message from the body of an HTTP request.
 - The decoded protobuf message of the specified type.
 """
 function protobuf(request::HTTP.Request, type::Type{T}) :: T where {T}
-    io = IOBuffer(request.body)
+    body = request.body isa HTTP.EmptyBody ? UInt8[] : copy(request.body)
+    io = IOBuffer(body)
     return decode(ProtoDecoder(io), type)
 end
 
 function protobuf(response::HTTP.Response, type::Type{T}) :: T where {T}
-    io = IOBuffer(response.body)
+    body = response.body isa HTTP.EmptyBody ? UInt8[] : copy(response.body)
+    io = IOBuffer(body)
     return decode(ProtoDecoder(io), type)
 end
 

--- a/src/Oxygen.jl
+++ b/src/Oxygen.jl
@@ -11,9 +11,10 @@ end
 include("core.jl"); using .Core
 include("instances.jl"); using .Instances
 
-import HTTP: Request, Response, Stream, WebSocket, queryparams
+import HTTP: Request, Response, Stream
+import HTTP.WebSockets: WebSocket
 using .Core: ServerContext, History, Server, Nullable, HOFRouter
-using .Core: GET, POST, PUT, DELETE, PATCH
+using .Core: GET, POST, PUT, DELETE, PATCH, queryparams
 
 const CONTEXT :: Ref{ServerContext} = Ref(ServerContext())
 

--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -663,7 +663,7 @@ end
 Helper function used to determine if a type is a custom struct and whether or not
 we should do a recursive dive and conversion to openapi schema.
 
-Excludes built-in types from Base, Core, Dates, and HTTP.Messages modules.
+Excludes built-in types from Base, Core, Dates, and HTTP modules.
 Handles Union types by checking if any constituent type is a custom struct.
 
 # Examples
@@ -683,8 +683,8 @@ function is_custom_struct(T::Type) :: Bool
         return any(is_custom_struct, Base.uniontypes(T))
     end
 
-    # Exclude types from Base, Core, Dates, and HTTP.Messages
-    if T.name.module ∉ (Base, Core, Dates, HTTP.Messages)
+    # Exclude types from Base, Core, Dates, and HTTP
+    if T.name.module ∉ (Base, Core, Dates, HTTP)
         return isstructtype(T) || isabstracttype(T)
     end
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -43,7 +43,7 @@ const METHOD_ALIASES :: Dict{String,String} = Dict(
 
 const TYPE_ALIASES :: Dict{String, Type} = Dict(
     WEBSOCKET   => HTTP.WebSockets.WebSocket,
-    STREAM      => HTTP.Streams.Stream
+    STREAM      => HTTP.Stream
 )
 
 const SWAGGER_VERSION   :: String = "swagger@5.7.2"

--- a/src/core.jl
+++ b/src/core.jl
@@ -26,6 +26,7 @@ include("repeattasks.jl");  @reexport using .RepeatTasks
 include("metrics.jl");      @reexport using .Metrics
 include("reflection.jl");   @reexport using .Reflection
 include("extractors.jl");   @reexport using .Extractors
+using .Extractors: Form  # Prefer over HTTP.Form
 include("autodoc.jl");      @reexport using .AutoDoc
 
 export start, serve, serveparallel, terminate,
@@ -168,7 +169,7 @@ function serve(ctx::ServerContext;
     # The cleanup of resources are put at the topmost level in `methods.jl`
     try
         return startserver(ctx; host, port, show_banner, docs, metrics, parallel, async, kwargs, start=(kwargs) ->
-            HTTP.serve!(handle_stream, host, port; kwargs...))
+            HTTP.listen!(handle_stream, host, port; kwargs...))
     finally
         if ctx.service.eager_revise[] !== nothing && async == false
             close(ctx.service.eager_revise[])
@@ -270,10 +271,25 @@ This is our root stream handler used in both serve() and serveparallel().
 This function determines how we handle all incoming requests
 """
 
+"""
+Convert the `HTTP.peeraddr` result (a `Reseau.TCP.SocketAddr`-like struct with a
+`.ip` tuple of octets, or `nothing` if unavailable) into a `Sockets.IPAddr`.
+"""
+function peeraddr_to_ip(addr) :: IPAddr
+    addr === nothing && return ip"0.0.0.0"
+    octets = addr.ip
+    if length(octets) == 4
+        return IPv4(octets...)
+    else
+        groups = ntuple(i -> UInt16(octets[2i - 1]) << 8 | UInt16(octets[2i]), 8)
+        return IPv6(groups...)
+    end
+end
+
 function stream_handler(middleware::Function)
     return function (stream::HTTP.Stream)
         # extract the caller's ip address
-        ip, _ = Sockets.getpeername(stream)
+        ip = peeraddr_to_ip(HTTP.peeraddr(stream))
         # build up a streamhandler to handle our incoming requests
         handle_stream = HTTP.streamhandler(middleware |> decorate_request(ip, stream))
         # handle the incoming request
@@ -379,19 +395,13 @@ end
 
 
 """
-Used to overwrite defaults to any incoming keyword arguments
+Removes deprecated keys from incoming keyword arguments, currently: :stream, :access_log, and :queuesize.
 """
 function preprocesskwargs(kwargs)
     kwargs_dict = Dict{Symbol,Any}(kwargs)
-
-    # always set to streaming mode (regardless of what was passed)
-    kwargs_dict[:stream] = true
-
-    # user passed no loggin preferences - use defualt logging format 
-    if isempty(kwargs_dict) || !haskey(kwargs_dict, :access_log)
-        kwargs_dict[:access_log] = logfmt"$time_iso8601 - $remote_addr:$remote_port - \"$request\" $status"
-    end
-
+    delete!(kwargs_dict, :stream)
+    delete!(kwargs_dict, :access_log)
+    delete!(kwargs_dict, :queuesize)
     return kwargs_dict
 end
 
@@ -436,8 +446,7 @@ function DocsMiddleware(docsrouter::Router, docspath::String)
             else
                 response = handle(req)
             end
-            format_response!(req, response)
-            return req.response
+            return format_response(req, response)
         end
     end
 end
@@ -451,8 +460,7 @@ function DefaultSerializer(catch_errors::Bool; show_errors::Bool)
         return function (req::HTTP.Request)
             return handlerequest(catch_errors; show_errors) do
                 response = handle(req)
-                format_response!(req, response)
-                return req.response
+                return format_response(req, response)
             end
         end
     end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -7,7 +7,7 @@ using ..AppContext: ServerContext
 export select_handler, first_arg_type
 
 # Union type of supported Handlers
-HandlerArgType = Union{HTTP.Messages.Request, HTTP.WebSockets.WebSocket, HTTP.Streams.Stream}
+HandlerArgType = Union{HTTP.Request, HTTP.WebSockets.WebSocket, HTTP.Stream}
 
 function get_context(ctx::ServerContext)
     app_ctx = ctx.app_context[]
@@ -23,55 +23,55 @@ request. This is a performance critical path and should be as fast as possible.
 function get_invoker_strategy(has_ctx_kwarg::Bool, has_req_kwarg::Bool, has_path_params::Bool, no_args::Bool, ctx::ServerContext)
     if no_args
         if has_req_kwarg && has_ctx_kwarg
-            return function (func::Function, _::HandlerArgType, req::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, _::HandlerArgType, req::HTTP.Request, _::Nullable{Vector})
                 func(; request=req, context=get_context(ctx))
             end
         elseif has_req_kwarg
-            return function (func::Function, _::HandlerArgType, req::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, _::HandlerArgType, req::HTTP.Request, _::Nullable{Vector})
                 func(; request=req)
             end
         elseif has_ctx_kwarg
-            return function (func::Function, _::HandlerArgType, _::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, _::HandlerArgType, _::HTTP.Request, _::Nullable{Vector})
                 func(; context=get_context(ctx))
             end
         else
-            return function (func::Function, _::HandlerArgType, _::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, _::HandlerArgType, _::HTTP.Request, _::Nullable{Vector})
                 func()
             end
         end
     elseif has_path_params
         if has_req_kwarg && has_ctx_kwarg
-            return function (func::Function, arg::HandlerArgType, req::HTTP.Messages.Request, parameters::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, req::HTTP.Request, parameters::Nullable{Vector})
                 func(arg, parameters...; request=req, context=get_context(ctx))
             end
         elseif has_req_kwarg
-            return function (func::Function, arg::HandlerArgType, req::HTTP.Messages.Request, parameters::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, req::HTTP.Request, parameters::Nullable{Vector})
                 func(arg, parameters...; request=req)
             end
         elseif has_ctx_kwarg
-            return function (func::Function, arg::HandlerArgType, _::HTTP.Messages.Request, parameters::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, _::HTTP.Request, parameters::Nullable{Vector})
                 func(arg, parameters...; context=get_context(ctx))
             end
         else
-            return function (func::Function, arg::HandlerArgType, _::HTTP.Messages.Request, parameters::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, _::HTTP.Request, parameters::Nullable{Vector})
                 func(arg, parameters...)
             end
         end
     else
         if has_req_kwarg && has_ctx_kwarg
-            return function (func::Function, arg::HandlerArgType, req::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, req::HTTP.Request, _::Nullable{Vector})
                 func(arg; request=req, context=get_context(ctx))
             end
         elseif has_req_kwarg
-            return function (func::Function, arg::HandlerArgType, req::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, req::HTTP.Request, _::Nullable{Vector})
                 func(arg; request=req)
             end
         elseif has_ctx_kwarg
-            return function (func::Function, arg::HandlerArgType, _::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, _::HTTP.Request, _::Nullable{Vector})
                 func(arg; context=get_context(ctx))
             end
         else
-            return function (func::Function, arg::HandlerArgType, _::HTTP.Messages.Request, _::Nullable{Vector})
+            return function (func::Function, arg::HandlerArgType, _::HTTP.Request, _::Nullable{Vector})
                 func(arg)
             end
         end
@@ -93,11 +93,11 @@ function select_handler(::Type{T}, has_ctx_kwarg::Bool, has_req_kwarg::Bool, has
 end
 
 """
-    select_handler(::Type{HTTP.Streams.Stream})
+    select_handler(::Type{HTTP.Stream})
 
-Returns a handler for `HTTP.Streams.Stream` types
+Returns a handler for `HTTP.Stream` types
 """
-function select_handler(::Type{HTTP.Streams.Stream}, has_ctx_kwarg::Bool, has_req_kwarg::Bool, has_path_params::Bool, ctx::ServerContext; no_args=false)
+function select_handler(::Type{HTTP.Stream}, has_ctx_kwarg::Bool, has_req_kwarg::Bool, has_path_params::Bool, ctx::ServerContext; no_args=false)
     invoker = get_invoker_strategy(has_ctx_kwarg, has_req_kwarg, has_path_params, no_args, ctx)
     function (req::HTTP.Request, func::Function; parameters::Nullable{Vector}=nothing)
         invoker(func, req.context[:stream], req, parameters)

--- a/src/middleware/cors_middleware.jl
+++ b/src/middleware/cors_middleware.jl
@@ -51,7 +51,7 @@ function Cors(;
 
     return function(handle::Function)
         return function(req::HTTP.Request)
-            if HTTP.method(req) == "OPTIONS"
+            if req.method == "OPTIONS"
                 return HTTP.Response(200, cors_headers)
             else
                 response = handle(req)

--- a/src/middleware/extract_ip.jl
+++ b/src/middleware/extract_ip.jl
@@ -50,16 +50,16 @@ function extract_ip(req::HTTP.Request) :: IPAddr
 
     for (k, v) in req.headers
         # Case 1: Cloudflare's direct client IP header (return early since it's priority 1)
-        if lowercase(k) == lowercase("CF-Connecting-IP")
+        if k == "CF-Connecting-IP"
             return parse(IPAddr, v)
         # Case 2: Akamai/Enterprise proxies (True-Client-IP)
-        elseif isnothing(tci) && lowercase(k) == lowercase("True-Client-IP")
+        elseif isnothing(tci) && k == "True-Client-IP"
             tci = v
         # Case 3: Standard X-Forwarded-For header (may be a list)
-        elseif isnothing(xff) && lowercase(k) == lowercase("X-Forwarded-For")
+        elseif isnothing(xff) && k == "X-Forwarded-For"
             xff = v
         # Case 4: Nginx or other proxies (X-Real-IP)
-        elseif isnothing(xri) && lowercase(k) == lowercase("X-Real-IP")
+        elseif isnothing(xri) && k == "X-Real-IP"
             xri = v
         end
     end

--- a/src/middleware/extract_ip.jl
+++ b/src/middleware/extract_ip.jl
@@ -50,16 +50,16 @@ function extract_ip(req::HTTP.Request) :: IPAddr
 
     for (k, v) in req.headers
         # Case 1: Cloudflare's direct client IP header (return early since it's priority 1)
-        if HTTP.Messages.field_name_isequal(k, "CF-Connecting-IP")
+        if lowercase(k) == lowercase("CF-Connecting-IP")
             return parse(IPAddr, v)
         # Case 2: Akamai/Enterprise proxies (True-Client-IP)
-        elseif isnothing(tci) && HTTP.Messages.field_name_isequal(k, "True-Client-IP")
+        elseif isnothing(tci) && lowercase(k) == lowercase("True-Client-IP")
             tci = v
         # Case 3: Standard X-Forwarded-For header (may be a list)
-        elseif isnothing(xff) && HTTP.Messages.field_name_isequal(k, "X-Forwarded-For")
+        elseif isnothing(xff) && lowercase(k) == lowercase("X-Forwarded-For")
             xff = v
         # Case 4: Nginx or other proxies (X-Real-IP)
-        elseif isnothing(xri) && HTTP.Messages.field_name_isequal(k, "X-Real-IP")
+        elseif isnothing(xri) && lowercase(k) == lowercase("X-Real-IP")
             xri = v
         end
     end

--- a/src/middleware/rate_limiter.jl
+++ b/src/middleware/rate_limiter.jl
@@ -366,13 +366,13 @@ function set_rate_headers!(resp::HTTP.Response, rate_limit::Int, remaining_reque
         # End if all headers are found
         if has_retry && has_limit && has_remaining && has_reset
             break
-        elseif !has_retry && lowercase(k) == lowercase("Retry-After")
+        elseif !has_retry && k == "Retry-After"
             has_retry = true
-        elseif !has_limit && lowercase(k) == lowercase("X-RateLimit-Limit")
+        elseif !has_limit && k == "X-RateLimit-Limit"
             has_limit = true
-        elseif !has_remaining && lowercase(k) == lowercase("X-RateLimit-Remaining" )
+        elseif !has_remaining && k == "X-RateLimit-Remaining"
             has_remaining = true
-        elseif !has_reset && lowercase(k) == lowercase("X-RateLimit-Reset")
+        elseif !has_reset && k == "X-RateLimit-Reset"
             has_reset = true
         end
     end

--- a/src/middleware/rate_limiter.jl
+++ b/src/middleware/rate_limiter.jl
@@ -366,13 +366,13 @@ function set_rate_headers!(resp::HTTP.Response, rate_limit::Int, remaining_reque
         # End if all headers are found
         if has_retry && has_limit && has_remaining && has_reset
             break
-        elseif !has_retry && HTTP.Messages.field_name_isequal(k, "Retry-After")
+        elseif !has_retry && lowercase(k) == lowercase("Retry-After")
             has_retry = true
-        elseif !has_limit && HTTP.Messages.field_name_isequal(k, "X-RateLimit-Limit")
+        elseif !has_limit && lowercase(k) == lowercase("X-RateLimit-Limit")
             has_limit = true
-        elseif !has_remaining && HTTP.Messages.field_name_isequal(k, "X-RateLimit-Remaining" )
+        elseif !has_remaining && lowercase(k) == lowercase("X-RateLimit-Remaining" )
             has_remaining = true
-        elseif !has_reset && HTTP.Messages.field_name_isequal(k, "X-RateLimit-Reset")
+        elseif !has_reset && lowercase(k) == lowercase("X-RateLimit-Reset")
             has_reset = true
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -138,9 +138,7 @@ end
 
 function headers(req::LazyRequest) :: Nullable{Dict{String,String}}
     if isnothing(req.headers[])
-        # header names are case-insensitive; lowercase them so lookups by
-        # (lowercase) struct field name work regardless of wire casing
-        req.headers[] = Dict(lowercase(String(k)) => String(v) for (k,v) in req.request.headers)
+        req.headers[] = Dict(req.request.headers)
     end
     return req.headers[] 
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -138,7 +138,9 @@ end
 
 function headers(req::LazyRequest) :: Nullable{Dict{String,String}}
     if isnothing(req.headers[])
-        req.headers[] = Dict(String(k) => String(v) for (k,v) in HTTP.headers(req.request))
+        # header names are case-insensitive; lowercase them so lookups by
+        # (lowercase) struct field name work regardless of wire casing
+        req.headers[] = Dict(lowercase(String(k)) => String(v) for (k,v) in req.request.headers)
     end
     return req.headers[] 
 end
@@ -152,7 +154,7 @@ end
 
 function queryvars(req::LazyRequest) :: Nullable{Dict{String,String}}
     if isnothing(req.queryparams[])
-        req.queryparams[] = HTTP.queryparams(req.request)
+        req.queryparams[] = HTTP.queryparams(HTTP.URI(req.request.target).query)
     end
     return req.queryparams[]
 end

--- a/src/utilities/bodyparsers.jl
+++ b/src/utilities/bodyparsers.jl
@@ -1,10 +1,12 @@
-
-using HTTP 
+using HTTP
 using JSON
+using URIs
 
 export text, binary, json, formdata
 
 ### Helper functions used to parse the body of a HTTP.Request object
+
+request_bytes(req::HTTP.Request) = req.body isa HTTP.EmptyBody ? UInt8[] : copy(req.body)
 
 """
     text(request::HTTP.Request)
@@ -12,7 +14,7 @@ export text, binary, json, formdata
 Read the body of a HTTP.Request as a String
 """
 function text(req::HTTP.Request) :: String
-    body = IOBuffer(HTTP.payload(req))
+    body = IOBuffer(request_bytes(req))
     return eof(body) ? nothing : read(seekstart(body), String)
 end
 
@@ -33,7 +35,7 @@ end
 Read the body of a HTTP.Request as a Vector{UInt8}
 """
 function binary(req::HTTP.Request) :: Vector{UInt8}
-    body = IOBuffer(HTTP.payload(req))
+    body = IOBuffer(request_bytes(req))
     return eof(body) ? nothing : readavailable(body)
 end
 
@@ -44,8 +46,8 @@ end
 Read the body of a HTTP.Request as JSON with additional arguments for the read/serializer.
 """
 function json(req::HTTP.Request; kwargs...)
-    body = IOBuffer(HTTP.payload(req))
-    return eof(body) ? nothing : JSON.parse(body; kwargs...)    
+    body = IOBuffer(request_bytes(req))
+    return eof(body) ? nothing : JSON.parse(body; kwargs...)
 end
 
 """
@@ -54,13 +56,29 @@ end
 Read the body of a HTTP.Request as JSON with additional arguments for the read/serializer into a custom struct.
 """
 function json(req::HTTP.Request, class_type::Type{T}; kwargs...) :: T where {T}
-    body = IOBuffer(HTTP.payload(req))
-    return eof(body) ? nothing : JSON.parse(body, class_type; kwargs...)    
+    body = IOBuffer(request_bytes(req))
+    return eof(body) ? nothing : JSON.parse(body, class_type; kwargs...)
 end
 
 
 ### Helper functions used to parse the body of an HTTP.Response object
 
+function response_bytes(response::HTTP.Response) :: Vector{UInt8}
+    body = response.body
+    body isa HTTP.EmptyBody && return UInt8[]
+    body isa HTTP.BytesBody && return copy(body)
+    # raw String/Vector{UInt8} bodies assigned directly to a response
+    body isa HTTP.AbstractBody || return Vector{UInt8}(body)
+    # streaming bodies (e.g. file responses from HTTP.servefile) can only be drained incrementally
+    out = IOBuffer()
+    buffer = Vector{UInt8}(undef, 8192)
+    while true
+        n = HTTP.body_read!(body, buffer)
+        n == 0 && break
+        write(out, view(buffer, 1:n))
+    end
+    return take!(out)
+end
 
 """
     text(response::HTTP.Response)
@@ -68,7 +86,7 @@ end
 Read the body of a HTTP.Response as a String
 """
 function text(response::HTTP.Response) :: String
-    return String(response.body)
+    return String(response_bytes(response))
 end
 
 """
@@ -87,7 +105,7 @@ end
 Read the body of a HTTP.Response as JSON with additional keyword arguments
 """
 function json(response::HTTP.Response; kwargs...) :: JSON.Object
-    return JSON.parse(response.body; kwargs...)
+    return JSON.parse(response_bytes(response); kwargs...)
 end
 
 
@@ -97,7 +115,7 @@ end
 Read the body of a HTTP.Response as JSON with additional keyword arguments and serialize it into a custom struct
 """
 function json(response::HTTP.Response, class_type::Type{T}; kwargs...) :: T where {T}
-    return JSON.parse(response.body, class_type; kwargs...)
+    return JSON.parse(response_bytes(response), class_type; kwargs...)
 end
 
 

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -5,8 +5,8 @@ using Dates
 using ..Errors: ValidationError
 
 export recursive_merge, parseparam, 
-    redirect, handlerequest,
-    format_response!, set_content_size!, format_sse_message,
+    redirect, queryparams, handlerequest,
+    format_response, set_content_size!, format_sse_message,
     join_url_path
 
 ### Request helper functions ###
@@ -78,6 +78,13 @@ function recursive_merge(x::AbstractVector...)
 end 
 
 """
+    Query parameter helpers, shadowing URIs.queryparams
+"""
+queryparams(x) = URIs.queryparams(x)
+queryparams(req::HTTP.Request) = URIs.queryparams(URI(req.target))
+queryparams(resp::HTTP.Response) = resp.request !== nothing ? queryparams(resp.request) : nothing
+
+"""
     Path Parameter Parsing functions
 """
 
@@ -144,39 +151,36 @@ end
     Response Formatter functions
 """
 
-function format_response!(req::HTTP.Request, resp::HTTP.Response)
+function format_response(req::HTTP.Request, resp::HTTP.Response) :: HTTP.Response
     # Return Response's as is without any modifications
-    req.response = resp
+    return resp
 end
 
-function format_response!(req::HTTP.Request, content::AbstractString)
+function format_response(req::HTTP.Request, content::AbstractString) :: HTTP.Response
     # Dynamically determine the content type when given a string
     body = string(content)
-    HTTP.setheader(req.response, "Content-Type" => HTTP.sniff(body))
-    HTTP.setheader(req.response, "Content-Length" => string(sizeof(body)))
-
-    req.response.status = 200
-    req.response.body = content
+    resp = HTTP.Response(200, body)
+    HTTP.setheader(resp, "Content-Type" => HTTP.sniff(body))
+    HTTP.setheader(resp, "Content-Length" => string(sizeof(body)))
+    return resp
 end
 
-function format_response!(req::HTTP.Request, content::Union{Number, Bool, Char, Symbol})
+function format_response(req::HTTP.Request, content::Union{Number, Bool, Char, Symbol}) :: HTTP.Response
     # Convert all primitvies to a string and set the content type to text/plain
     body = string(content)
-    HTTP.setheader(req.response, "Content-Type" => "text/plain; charset=utf-8")
-    HTTP.setheader(req.response, "Content-Length" => string(sizeof(body)))
-
-    req.response.status = 200
-    req.response.body = body
+    resp = HTTP.Response(200, body)
+    HTTP.setheader(resp, "Content-Type" => "text/plain; charset=utf-8")
+    HTTP.setheader(resp, "Content-Length" => string(sizeof(body)))
+    return resp
 end
 
-function format_response!(req::HTTP.Request, content::Any)
+function format_response(req::HTTP.Request, content::Any) :: HTTP.Response
     # Convert anthything else to a JSON string
     body = JSON.json(content)
-    HTTP.setheader(req.response, "Content-Type" => "application/json; charset=utf-8")
-    HTTP.setheader(req.response, "Content-Length" => string(sizeof(body)))
-
-    req.response.status = 200
-    req.response.body = body    
+    resp = HTTP.Response(200, body)
+    HTTP.setheader(resp, "Content-Type" => "application/json; charset=utf-8")
+    HTTP.setheader(resp, "Content-Length" => string(sizeof(body)))
+    return resp
 end
 
 

--- a/src/utilities/render.jl
+++ b/src/utilities/render.jl
@@ -124,7 +124,7 @@ an ArgumentError is thrown. The MIME type and the size of the file are added to 
 """
 function file(filepath::String; loadfile = nothing, status = 200, headers = []) :: HTTP.Response
     has_loadfile    = !isnothing(loadfile)
-    content         = has_loadfile ? loadfile(filepath) : read(filepath, String)
+    content         = has_loadfile ? loadfile(filepath) : read(filepath)
     content_length  = has_loadfile ? string(sizeof(content)) : string(filesize(filepath))
     content_type    = mime_from_path(filepath, MIME"application/octet-stream"()) |> contenttype_from_mime
     response = HTTP.Response(status, headers, body = content)

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -186,7 +186,7 @@ end
         return data.payload
     end
 
-    @post "/form-test" function(req, data::Form{EnumTopLevel})
+    @post "/form-test" function(req, data::Oxygen.Form{EnumTopLevel})
         return data.payload
     end
 

--- a/test/extractortests.jl
+++ b/test/extractortests.jl
@@ -84,7 +84,7 @@ end
 
 @testset "Form extract" begin 
     req = HTTP.Request("GET", "/", [], """name=joe&age=25""")
-    param = Param(:form, Form{Person}, missing, false)
+    param = Param(:form, Oxygen.Form{Person}, missing, false)
     p = extract(param, LazyRequest(request=req)).payload
     @test p.name == "joe"
     @test p.age == 25
@@ -92,14 +92,14 @@ end
 
     # Test that negative age trips the global validator
     req = HTTP.Request("GET", "/", [], """name=joe&age=-4""")
-    param = Param(:form, Form{Person}, missing, false)
+    param = Param(:form, Oxygen.Form{Person}, missing, false)
     @test_throws Oxygen.Core.Errors.ValidationError extract(param, LazyRequest(request=req))
 
 
     # Test that age < 25 trips the local validator
     req = HTTP.Request("GET", "/", [], """name=joe&age=10""")
-    default_value = Form{Person}(x -> x.age > 25)
-    param = Param(:form, Form{Person}, default_value, true)
+    default_value = Oxygen.Form{Person}(x -> x.age > 25)
+    param = Param(:form, Oxygen.Form{Person}, default_value, true)
     @test_throws Oxygen.Core.Errors.ValidationError extract(param, LazyRequest(request=req))
 end
 
@@ -181,7 +181,7 @@ end
         return headers.payload
     end
 
-    post("/form") do req, form::Form{Sample}
+    post("/form") do req, form::Oxygen.Form{Sample}
         return form.payload |> json
     end
 

--- a/test/middleware/ratelimitter_lru_tests.jl
+++ b/test/middleware/ratelimitter_lru_tests.jl
@@ -153,7 +153,7 @@ sleep(3.1) # Ensure rate limiter window is reset before starting next testset
 @testset "Limited Other Endpoint Rate Limiter" begin
     # First 25 requests should succeed (route-level limit enforced, headers show route-level limit)
     for i in 1:25
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 200
         @test text(r) == "goodbye"
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"  # Headers set by route-level middleware
@@ -164,7 +164,7 @@ sleep(3.1) # Ensure rate limiter window is reset before starting next testset
 
     # 26-28th request should be rate limited (429) - route-level limit enforced
     for i in 1:3
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 429
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"  # Headers show route-level
         @test HTTP.header(r, "X-RateLimit-Remaining") == "0"
@@ -177,7 +177,7 @@ sleep(3.1) # Ensure rate limiter window is reset before starting next testset
 
     # Next 25 requests should succeed again after reset
     for i in 1:25
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 200
         @test text(r) == "goodbye"
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"
@@ -188,7 +188,7 @@ sleep(3.1) # Ensure rate limiter window is reset before starting next testset
 
     # 26-28th request in the new window should be rate limited again
     for i in 1:3
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 429
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"
         @test HTTP.header(r, "X-RateLimit-Remaining") == "0"

--- a/test/middleware/ratelimitter_tests.jl
+++ b/test/middleware/ratelimitter_tests.jl
@@ -7,9 +7,13 @@ using Sockets
 using Oxygen; @oxidize
 using ..Constants
 
-limit = router("/limited", middleware=[RateLimiter(rate_limit=50, window_period=Second(3))])
+# Reuse a single client/connection across requests to avoid the per-request
+# connect overhead that would otherwise make these tight timing windows flaky.
+client = HTTP.Client()
 
-@get limit("/goodbye", middleware=[RateLimiter(rate_limit=25, window=Second(3))]) function()
+limit = router("/limited", middleware=[RateLimiter(rate_limit=50, window_period=Second(10))])
+
+@get limit("/goodbye", middleware=[RateLimiter(rate_limit=25, window=Second(10))]) function()
     return "goodbye"
 end
 
@@ -28,7 +32,7 @@ serve(middleware=[RateLimiter(rate_limit=100, window=Second(3))], port=PORT, hos
 
     # First 100 requests should succeed with decreasing remaining count
     for i in 1:100
-        r = HTTP.get("$localhost/ok")
+        r = HTTP.get(client, "$localhost/ok")
         @test r.status == 200
         @test text(r) == "ok"
         @test HTTP.header(r, "X-RateLimit-Limit") == "100"
@@ -40,7 +44,7 @@ serve(middleware=[RateLimiter(rate_limit=100, window=Second(3))], port=PORT, hos
     # 101-103rd request should be rate limited (429) with proper headers
     for i in 1:3
         try
-            HTTP.get("$localhost/ok"; retry=false)
+            HTTP.get(client, "$localhost/ok"; retry=false)
             @test false  # Should not reach here
         catch e
             @test e isa HTTP.Exceptions.StatusError
@@ -57,7 +61,7 @@ serve(middleware=[RateLimiter(rate_limit=100, window=Second(3))], port=PORT, hos
 
     # Next 100 requests should succeed again with decreasing remaining count
     for i in 1:100
-        r = HTTP.get("$localhost/ok")
+        r = HTTP.get(client, "$localhost/ok")
         @test r.status == 200
         @test text(r) == "ok"
         @test HTTP.header(r, "X-RateLimit-Limit") == "100"
@@ -69,7 +73,7 @@ serve(middleware=[RateLimiter(rate_limit=100, window=Second(3))], port=PORT, hos
     # 101-103rd request in the new window should be rate limited again
     for i in 1:3
         try
-            HTTP.get("$localhost/ok"; retry=false)
+            HTTP.get(client, "$localhost/ok"; retry=false)
             @test false
         catch e
             @test e isa HTTP.Exceptions.StatusError
@@ -94,19 +98,19 @@ sleep(5) # Ensure rate limiter window is completely reset and any background cle
 @testset "Limited Greet Endpoint Rate Limiter" begin
     # First 50 requests should succeed with decreasing remaining count
     for i in 1:50
-        r = HTTP.get("$localhost/limited/greet")
+        r = HTTP.get(client, "$localhost/limited/greet")
         @test r.status == 200
         @test text(r) == "hello"
         @test HTTP.header(r, "X-RateLimit-Limit") == "50"
         @test HTTP.header(r, "X-RateLimit-Remaining") == string(50 - i)
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 
     # 51-53rd request should be rate limited (429)
     for i in 1:3
         try
-            HTTP.get("$localhost/limited/greet"; retry=false)
+            HTTP.get(client, "$localhost/limited/greet"; retry=false)
             @test false
         catch e
             @test e isa HTTP.Exceptions.StatusError
@@ -114,28 +118,28 @@ sleep(5) # Ensure rate limiter window is completely reset and any background cle
             @test HTTP.header(e.response, "X-RateLimit-Limit") == "50"
             @test HTTP.header(e.response, "X-RateLimit-Remaining") == "0"
             reset_time = parse(Int, HTTP.header(e.response, "X-RateLimit-Reset"))
-            @test reset_time > 0 && reset_time <= 3
+            @test reset_time > 0 && reset_time <= 10
         end
     end
 
     # Wait for the window to reset (just over 3 seconds)
-    sleep(3.1)
+    sleep(10.1)
 
     # Next 50 requests should succeed again
     for i in 1:50
-        r = HTTP.get("$localhost/limited/greet")
+        r = HTTP.get(client, "$localhost/limited/greet")
         @test r.status == 200
         @test text(r) == "hello"
         @test HTTP.header(r, "X-RateLimit-Limit") == "50"
         @test HTTP.header(r, "X-RateLimit-Remaining") == string(50 - i)
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 
     # 51-53rd request in the new window should be rate limited again
     for i in 1:3
         try
-            HTTP.get("$localhost/limited/greet"; retry=false)
+            HTTP.get(client, "$localhost/limited/greet"; retry=false)
             @test false
         catch e
             @test e isa HTTP.Exceptions.StatusError
@@ -143,57 +147,57 @@ sleep(5) # Ensure rate limiter window is completely reset and any background cle
             @test HTTP.header(e.response, "X-RateLimit-Limit") == "50"
             @test HTTP.header(e.response, "X-RateLimit-Remaining") == "0"
             reset_time = parse(Int, HTTP.header(e.response, "X-RateLimit-Reset"))
-            @test reset_time > 0 && reset_time <= 3
+            @test reset_time > 0 && reset_time <= 10
         end
     end
 end
 
-sleep(3.1) # Ensure rate limiter window is reset before starting next testset
+sleep(10.1) # Ensure rate limiter window is reset before starting next testset
 
 @testset "Limited Other Endpoint Rate Limiter" begin
     # First 25 requests should succeed (route-level limit enforced, headers show route-level limit)
     for i in 1:25
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request(client, "GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 200
         @test text(r) == "goodbye"
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"  # Headers set by route-level middleware
         @test HTTP.header(r, "X-RateLimit-Remaining") == string(25 - i)
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 
     # 26-28th request should be rate limited (429) - route-level limit enforced
     for i in 1:3
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request(client, "GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 429
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"  # Headers show route-level
         @test HTTP.header(r, "X-RateLimit-Remaining") == "0"
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 
     # Wait for the window to reset (just over 3 seconds)
-    sleep(3.1)
+    sleep(10.1)
 
     # Next 25 requests should succeed again after reset
     for i in 1:25
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request(client, "GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 200
         @test text(r) == "goodbye"
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"
         @test HTTP.header(r, "X-RateLimit-Remaining") == string(25 - i)
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 
     # 26-28th request in the new window should be rate limited again
     for i in 1:3
-        r = HTTP.request("GET", "$localhost/limited/goodbye", status_exception=false)
+        r = HTTP.request(client, "GET", "$localhost/limited/goodbye", status_exception=false, retry=false)
         @test r.status == 429
         @test HTTP.header(r, "X-RateLimit-Limit") == "25"
         @test HTTP.header(r, "X-RateLimit-Remaining") == "0"
         reset_time = parse(Int, HTTP.header(r, "X-RateLimit-Reset"))
-        @test reset_time > 0 && reset_time <= 3
+        @test reset_time > 0 && reset_time <= 10
     end
 end
 
@@ -207,7 +211,7 @@ serve(middleware=[rl], port=PORT, host=HOST, async=true, show_errors=false, show
 @testset "Background Cleanup Test" begin
 
     # First request should succeed
-    r = HTTP.get("$localhost/ok"; retry=false)
+    r = HTTP.get(client, "$localhost/ok"; retry=false)
     @test r.status == 200
     @test text(r) == "ok"
     @test HTTP.header(r, "X-RateLimit-Limit") == "1"
@@ -217,7 +221,7 @@ serve(middleware=[rl], port=PORT, host=HOST, async=true, show_errors=false, show
 
     # Second request should be rate limited (429)
     try
-        HTTP.get("$localhost/ok"; retry=false)
+        HTTP.get(client, "$localhost/ok"; retry=false)
         @test false
     catch e
         @test e isa HTTP.Exceptions.StatusError
@@ -232,7 +236,7 @@ serve(middleware=[rl], port=PORT, host=HOST, async=true, show_errors=false, show
     sleep(2.1)
 
     # Third request should succeed because the IP entry was cleaned up
-    r = HTTP.get("$localhost/ok"; retry=false)
+    r = HTTP.get(client, "$localhost/ok"; retry=false)
     @test r.status == 200
     @test text(r) == "ok"
     @test HTTP.header(r, "X-RateLimit-Limit") == "1"
@@ -257,7 +261,7 @@ serve(middleware=[RateLimiter(rate_limit=10, window=Second(1), exempt_paths=["/e
 @testset "Exempt Paths Test" begin
     # First 10 requests to /limited should succeed with decreasing remaining count
     for i in 1:10
-        r = HTTP.get("$localhost/limited")
+        r = HTTP.get(client, "$localhost/limited")
         @test r.status == 200
         @test text(r) == "limited"
         @test HTTP.header(r, "X-RateLimit-Limit") == "10"
@@ -268,7 +272,7 @@ serve(middleware=[RateLimiter(rate_limit=10, window=Second(1), exempt_paths=["/e
 
     # 11th request to /limited should be rate limited (429)
     try
-        HTTP.get("$localhost/limited"; retry=false)
+        HTTP.get(client, "$localhost/limited"; retry=false)
         @test false
     catch e
         @test e isa HTTP.Exceptions.StatusError
@@ -281,7 +285,7 @@ serve(middleware=[RateLimiter(rate_limit=10, window=Second(1), exempt_paths=["/e
 
     # Requests to /exempt should succeed even when rate limit is exceeded, and should not have rate limit headers
     for i in 1:5
-        r = HTTP.get("$localhost/exempt")
+        r = HTTP.get(client, "$localhost/exempt")
         @test r.status == 200
         @test text(r) == "exempt"
         # Exempt paths should not have rate limit headers

--- a/test/paralleltests.jl
+++ b/test/paralleltests.jl
@@ -72,7 +72,7 @@ using ..Constants
         try
             @suppress_err r = HTTP.get("$localhost/customerror", connect_timeout=3)
         catch e 
-            @test e isa MethodError || e isa HTTP.ExceptionRequest.StatusError
+            @test e isa MethodError || e isa HTTP.Exceptions.StatusError
         end
         
         terminate()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ include("cronmanagement.jl")
 include("middlewaretests.jl")
 include("appcontexttests.jl")
 include("path_prefix_tests.jl")
+include("staticfilestests.jl")
 include("originaltests.jl")
 include("revise.jl")
 

--- a/test/scenarios/thunderingherd.jl
+++ b/test/scenarios/thunderingherd.jl
@@ -15,7 +15,7 @@ cors_headers = [
 function CorsHandler(handle)
     return function (req::HTTP.Request)
         # return headers on OPTIONS request
-        if HTTP.method(req) == "OPTIONS"
+        if req.method == "OPTIONS"
             return HTTP.Response(200, cors_headers)
         else
             r = handle(req)

--- a/test/ssetests.jl
+++ b/test/ssetests.jl
@@ -14,13 +14,13 @@ stream("/events/{name}") do stream::HTTP.Stream, name::String
     HTTP.setheader(stream, "Access-Control-Allow-Methods" => "GET")
     HTTP.setheader(stream, "Content-Type" => "text/event-stream")
     HTTP.setheader(stream, "Cache-Control" => "no-cache")
-    startwrite(stream)
+    HTTP.startwrite(stream)
     message = "Hello, $name"
     for _ in 1:5
         write(stream, format_sse_message(message))
         sleep(0.1)
     end
-    closewrite(stream)
+    HTTP.closewrite(stream)
     return nothing
 end
 
@@ -30,7 +30,7 @@ serve(port=PORT, host=HOST, async=true, show_errors=false, show_banner=false, ac
 
 @testset "Stream Function tests" begin 
 
-    HTTP.open("GET", "$localhost/events/john", headers=Dict("Connection" => "close")) do io
+    HTTP.open("GET", "$localhost/events/john", ["Connection" => "close"]) do io
         while !eof(io)
             message = String(readavailable(io))
             if !isempty(message) && message != "null"
@@ -39,7 +39,7 @@ serve(port=PORT, host=HOST, async=true, show_errors=false, show_banner=false, ac
         end
     end
 
-    HTTP.open("GET", "$localhost/events/matt", headers=Dict("Connection" => "close")) do io
+    HTTP.open("GET", "$localhost/events/matt", ["Connection" => "close"]) do io
         while !eof(io)
             message = String(readavailable(io))
             if !isempty(message) && message != "null"

--- a/test/staticfilestests.jl
+++ b/test/staticfilestests.jl
@@ -1,0 +1,27 @@
+module StaticFilesTests
+using Test
+using HTTP
+using ..Constants
+using Oxygen; @oxidize
+
+staticfiles("content", "static")
+
+serve(port=PORT, host=HOST, async=true, show_errors=false, show_banner=false, access_log=nothing)
+
+@testset "staticfiles page can be hit more than once" begin
+    expected = read("content/test.txt", String)
+
+    r = HTTP.get("$localhost/static/test.txt")
+    @test r.status == 200
+    @test String(r.body) == expected
+
+    # a second request to the same mounted file must return the same content
+    r = HTTP.get("$localhost/static/test.txt")
+    @test r.status == 200
+    @test String(r.body) == expected
+end
+
+terminate()
+println()
+
+end

--- a/test/streamingtests.jl
+++ b/test/streamingtests.jl
@@ -10,7 +10,7 @@ function explicit_stream(stream::HTTP.Stream)
     HTTP.setheader(stream, "Transfer-Encoding" => "chunked")
 
     # Start writing (if you need to send headers before the body)
-    startwrite(stream)
+    HTTP.startwrite(stream)
 
     data = ["a", "b", "c"]
     for chunk in data
@@ -18,7 +18,7 @@ function explicit_stream(stream::HTTP.Stream)
     end
 
     # Close the stream to end the HTTP response properly
-    closewrite(stream)
+    HTTP.closewrite(stream)
 end
 
 function implicit_stream(stream)

--- a/test/test_reexports.jl
+++ b/test/test_reexports.jl
@@ -7,8 +7,7 @@ import Oxygen
     @test Oxygen.Request        == HTTP.Request
     @test Oxygen.Response       == HTTP.Response
     @test Oxygen.Stream         == HTTP.Stream
-    @test Oxygen.WebSocket      == HTTP.WebSocket
-    @test Oxygen.queryparams    == HTTP.queryparams
+    @test Oxygen.WebSocket      == HTTP.WebSockets.WebSocket
 end
 
 end

--- a/test/websockettests.jl
+++ b/test/websockettests.jl
@@ -5,10 +5,10 @@ using HTTP.WebSockets
 using ..Constants
 using Oxygen; @oxidize
 
-websocket("/ws") do ws::HTTP.WebSocket
+websocket("/ws") do ws::HTTP.WebSockets.WebSocket
     try 
         for msg in ws
-            send(ws, "Received message: $msg")
+            HTTP.WebSockets.send(ws, "Received message: $msg")
         end
     catch e 
         if !isa(e, HTTP.WebSockets.WebSocketError)
@@ -18,10 +18,10 @@ websocket("/ws") do ws::HTTP.WebSocket
 end
 
 wsrouter = router("/router")
-websocket(wsrouter("/ws")) do ws::HTTP.WebSocket
+websocket(wsrouter("/ws")) do ws::HTTP.WebSockets.WebSocket
     try 
         for msg in ws
-            send(ws, "Received message: $msg")
+            HTTP.WebSockets.send(ws, "Received message: $msg")
         end
     catch e 
         if !isa(e, HTTP.WebSockets.WebSocketError)
@@ -34,7 +34,7 @@ end
 @websocket "/ws/{x}" function(ws, x::Int)
     try 
         for msg in ws
-            send(ws, "Received message from $x: $msg")
+            HTTP.WebSockets.send(ws, "Received message from $x: $msg")
         end
     catch e
         if !isa(e, HTTP.WebSockets.WebSocketError)
@@ -44,10 +44,10 @@ end
 end
 
 # Test if @get works with WebSockets (based on the type of the first argument)
-@get "/ws/get" function(ws::HTTP.WebSocket)
+@get "/ws/get" function(ws::HTTP.WebSockets.WebSocket)
     try 
         for msg in ws
-            send(ws, "Received message: $msg")
+            HTTP.WebSockets.send(ws, "Received message: $msg")
         end
     catch e
         if !isa(e, HTTP.WebSockets.WebSocketError)
@@ -62,32 +62,32 @@ serve(port=PORT, host=HOST, async=true,  show_errors=false, show_banner=false, a
 
     @testset "/ws route" begin
         WebSockets.open("ws://$HOST:$PORT/ws") do ws
-            send(ws, "Test message")
-            response = receive(ws)
+            HTTP.WebSockets.send(ws, "Test message")
+            response = HTTP.WebSockets.receive(ws)
             @test response == "Received message: Test message"
         end
     end
 
     @testset "/router/ws route" begin
         WebSockets.open("ws://$HOST:$PORT/router/ws") do ws
-            send(ws, "Test message")
-            response = receive(ws)
+            HTTP.WebSockets.send(ws, "Test message")
+            response = HTTP.WebSockets.receive(ws)
             @test response == "Received message: Test message"
         end
     end
 
     @testset "/ws with arg route" begin
         WebSockets.open("ws://$HOST:$PORT/ws/9") do ws
-            send(ws, "Test message")
-            response = receive(ws)
+            HTTP.WebSockets.send(ws, "Test message")
+            response = HTTP.WebSockets.receive(ws)
             @test response == "Received message from 9: Test message"
         end
     end
 
     @testset "/ws with @get" begin
         WebSockets.open("ws://$HOST:$PORT/ws/get") do ws
-            send(ws, "Test message")
-            response = receive(ws)
+            HTTP.WebSockets.send(ws, "Test message")
+            response = HTTP.WebSockets.receive(ws)
             @test response == "Received message: Test message"
         end
     end


### PR DESCRIPTION
Closes https://github.com/OxygenFramework/Oxygen.jl/issues/299

PR is tool assisted but reviewed and manually polished.

This PR upgrades to HTTP.jl.

One wrinkle here is that access_log is removed completely. Perhaps we should have a middleware for this built in and install it when access_log is not `nothing`.

Another is that `queryparams` is removed. In this PR the shadow-and-dispatch-to-the-original pattern is used with URIs.queryparams is used to avoid type piracy and keep reasonable compatibility with old code.